### PR TITLE
bugfix & resize

### DIFF
--- a/onairpage.css
+++ b/onairpage.css
@@ -72,10 +72,10 @@
 [class*="TVContainer__balloon-"] { /* 緑色吹き出し非表示 */
     display:none;
 }
-[class^="TVContainer__right-comment-area___"] [class*="styles__comment-list___"] { /* 古いコメントを非表示 onairpage.jsで設定
+[class^="TVContainer__right-comment-area___"] [class*="styles__comment-list-wrapper___"]>* { /* 古いコメントを非表示 onairpage.jsで設定
     overflow: hidden!important;*/
 }
-[class^="TVContainer__right-comment-area___"] [class*="styles__comment-list___"] > div { /* コメント1行化用 */
+[class^="TVContainer__right-comment-area___"] [class*="styles__comment-list-wrapper___"]>*>div { /* コメント1行化用 */
     clear: both;
     padding: 1px 0px 1px 16px;
     border-top-color:rgba(255,255,255,0.5);

--- a/onairpage.js
+++ b/onairpage.js
@@ -793,6 +793,12 @@ function comesort(){
     }
   }
 }
+function otosageru(){
+    var teka=document.createEvent("MouseEvents");
+    var teki=$('[class^="styles__slider-container___"]').children();
+    teka.initMouseEvent("mousedown",true,true,window,0,0,0,teki.offset().left+15,teki.offset().top+106-92*0.3);
+    return teki[0].dispatchEvent(teka);
+}
 $(window).on('load', function () {
     console.log("loaded");
     var csspath = chrome.extension.getURL("onairpage.css");
@@ -866,6 +872,10 @@ $(window).on('load', function () {
         //黒帯パネル表示のためマウスを動かすイベント発火
         if (settings.isAlwaysShowPanel) {
             triggerMouseMoving();
+        }
+        //音量が最大なら30%に下げる
+        if($('[class^="styles__highlighter___"]').css("height")=="92px"){
+          otosageru();
         }
         //コメント取得
         var comments = $('[class^="TVContainer__right-comment-area___"] [class^="styles__message___"]');

--- a/onairpage.js
+++ b/onairpage.js
@@ -696,7 +696,7 @@ function popElement(){
     }
 }
 function waitforRightShown(retrycount){
-  var ss=4;
+  var ss=1;
 //  var ww=16*Math.floor(($(window).width()-(($(EXobli).siblings('[class*="TVContainer__right-slide--shown___"]').length>0)?310:0))/16);
   var ww=$(window).width();
   var wm=0;

--- a/option.html
+++ b/option.html
@@ -77,6 +77,9 @@
     <input type="checkbox" id="isAlwaysShowPanel">
     :常に黒帯パネルを表示する
     <br>
+    <input type="checkbox" id="isMovieResize">
+    :映像を枠に合わせて縮小する
+    <br>
     <input type="button" id="saveBtn" value="保存"><br>
     <span id="info"></span>
 </body>

--- a/option.js
+++ b/option.js
@@ -22,6 +22,7 @@ $(function(){
         var isTimeVisible = value.timeVisible || false;
         var isSureReadComment = value.sureReadComment || false;
         var isAlwaysShowPanel = value.isAlwaysShowPanel || false;
+        var isMovieResize = value.movieResize || false;
         $("#isResizeScreen").prop("checked", isResizeScreen);
         $("#isDblFullscreen").prop("checked", isDblFullscreen);
         $("#isEnterSubmit").prop("checked", isEnterSubmit);
@@ -42,6 +43,7 @@ $(function(){
         $("#isTimeVisible").prop("checked", isTimeVisible);
         $("#isSureReadComment").prop("checked", isSureReadComment);
         $("#isAlwaysShowPanel").prop("checked", isAlwaysShowPanel);
+        $("#isMovieResize").prop("checked", isMovieResize);
     });
     $("#saveBtn").click(function () {
         chrome.storage.local.set({
@@ -64,7 +66,8 @@ $(function(){
             "cancelWheel": $("#isCancelWheel").prop("checked"),
             "timeVisible": $("#isTimeVisible").prop("checked"),
             "sureReadComment": $("#isSureReadComment").prop("checked"),
-            "isAlwaysShowPanel": $("#isAlwaysShowPanel").prop("checked")
+            "isAlwaysShowPanel": $("#isAlwaysShowPanel").prop("checked"),
+            "movieResize": $("#isMovieResize").prop("checked")
         }, function () {
             $("#info").show().text("設定保存しました").fadeOut(4000);
         });


### PR DESCRIPTION
//月曜の仕様変更によるコメ欄まわりの見た目の修正
//コメ欄を開閉すると読込済コメ数が100個にリセットされる仕様に対応（自信なし）
//映像を枠内へ縮小するオプション追加（CM時は更にvar SSの分だけ縮小可能）
//右の放映中番組一覧の初期スクロール量の調整（視聴中番組が画面中央になるように）
//番組残り時間のバグ修正
//後から再利用できそうな変数EX...を追加
//音量が最大値の場合30%へ下げる（未オプション化）