### PR TITLE
Patch 1

### DIFF
--- a/onairpage.js
+++ b/onairpage.js
@@ -1980,7 +1980,7 @@ chrome.runtime.onMessage.addListener(function(r){
                 if(EXfootcome&&$(EXfootcome).next('#timerthird').length>0){
                     $(EXfootcome).next('#timerthird').text('CM');
                 }
-                if(cmblockcd!=1.72&&cmblockcd!=0.71){
+                if(cmblockcd!=1.72&&cmblockcd!=0.71&&cmblockcd*100%100!=62&&cmblockcd!=0.61){
                     cmblockcd=0;
                     startCM();
                 }
@@ -1996,7 +1996,7 @@ chrome.runtime.onMessage.addListener(function(r){
                     if(EXfootcome&&$(EXfootcome).next('#timerthird').length>0&&bginfo[0]>0){
                         $(EXfootcome).next('#timerthird').html('&nbsp;');
                     }
-                    if(cmblockcd!=-1.73&&cmblockcd!=-0.74){
+                    if(cmblockcd!=-1.73&&cmblockcd!=-0.74&&cmblockcd*100%100!=-63&&cmblockcd!=-0.64){
                         cmblockcd=0;
                         endCM();
                     }

--- a/onairpage.js
+++ b/onairpage.js
@@ -437,6 +437,8 @@ function openOption(sw){
     $('#itimePosition [type="radio"][name="timePosition"]').val([timePosition]);
     $('#itimePosition').css("display",isTimeVisible?"block":"none");
     $("#notifySeconds").val(notifySeconds);
+    $('#settcont>#windowresize>#movieheight input[type="radio"][name="movieheight"]').val([0]);
+    $('#settcont>#windowresize>#windowheight input[type="radio"][name="movieheight"]').val([0]);
 }
 function closeOption(){
     $("#settcont").css("display","none")
@@ -1313,6 +1315,7 @@ console.log("setOptionElement retry");
     }else{
         createTime(1);
     }
+    $(EXfootcome).css("pointer-events","auto");
 console.log("setOptionElement ok");
 }
 function usereventMouseover(){
@@ -1348,7 +1351,78 @@ function usereventVolMouseout(){
     if(!EXside){return;}
     $(EXside).css("transform","translate(0px,-50%)");
 }
+function usereventFCMouseout(){
+    if(!EXfootcome){return;}
+    $(EXfootcome).css("transition","")
+        .css("background-color","")
+    ;
+    $('body:first>#manualblockrd').remove();
+    if(cmblockcd*100%100==62){
+        cmblockcd=0.61;
+    }else if(cmblockcd*100%100==-63){
+        cmblockcd=-0.64;
+    }
+}
+function finishFCbgColored(){
+    if(cmblockcd>0){
+        cmblockcd=299.62;
+    }else if(cmblockcd<0){
+        cmblockcd=-299.63;
+    }
+    $(EXfootcome).css("transition","")
+        .css("background-color","")
+    ;
+    if($('body:first>#manualblockrd').length==0){
+        $('<div id="manualblockrd" class="manualblock"></div>').appendTo('body');
+        $('body:first>#manualblockrd').html('&nbsp;')
+            .css("position","absolute")
+            .css("height","5px")
+            .css("width","5px")
+            .css("bottom",0)
+            .css("right",0)
+            .css("background-color","magenta")
+            .css("z-index",20)
+        ;
+    }
+}
+function isFCbgColored(){
+    if(!EXfootcome){return false;}
+    var re=/^rgba?\( *(\d+) *, *(\d+) *, *(\d+) *(?:, *(\d+) *)?\)$/;
+    var tar=$(EXfootcome).css("background-color");
+    if(re.test(tar)){
+        var rex=re.exec(tar);
+        if(parseInt(rex[1])==255&&parseInt(rex[2])==0&&parseInt(rex[3])==255&&((rex[4]===undefined)||rex[4]==1)){
+            return true;
+        }else{return false;}
+    }else{return false;}
+}
+function chkFCbgc(retrycount){
+    if(isFCbgColored()){
+        finishFCbgColored();
+    }else if(retrycount>0){
+        setTimeout(chkFCbgc,100,retrycount-1);
+    }
+}
+function usereventFCMousemove(){
+    if(!EXfootcome){return;}
+    if(cmblockcd!=0&&$('body:first>#manualblockrd').length==0){
+        if($(EXfootcome).css("transition")!="background-color 1s linear 0s"){
+            $(EXfootcome).css("transition","background-color 1s linear 0s")
+                .css("background-color","rgb(255, 0, 255)")
+            ;
+            setTimeout(chkFCbgc,1000,10);
+        }
+        if(isFCbgColored()){
+            finishFCbgColored();
+        }
+    }else{
+        $(EXfootcome).css("transition","")
+            .css("background-color","")
+        ;
+    }
+}
 function setOptionEvent(){
+//自作要素のイベントは自作部分で対応
     if(eventAdded){return;}
     var butfs;
     var pwaku;
@@ -1417,29 +1491,57 @@ console.log("dblclick");
     $(EXvolume).on("mousemove",usereventVolMousemove);
     $(EXvolume).on("mouseout",usereventVolMouseout);
     window.addEventListener("keydown",function(e){
-        if(e.keyCode==38||e.keyCode==40){
+        if(e.keyCode==38||e.keyCode==40){ //38^ 40v
             if(isCancelWheel||isVolumeWheel){
                 e.stopPropagation();
             }
-        }else if(e.keyCode==17&&e.location==2){
-            if(cmblockcd==0){
-            }else if(cmblockcd>0){
-                cmblockcd=1.72;
-            }else if(cmblockcd<0){
-                cmblockcd=-1.73;
+        }else if(e.keyCode==17){ //17ctrl
+            if(cmblockcd!=0){
+                if(cmblockcd>0){
+                    cmblockcd=1.72;
+                }else if(cmblockcd<0){
+                    cmblockcd=-1.73;
+                }
+                var posi="";
+                if(e.location==1){
+                    posi="left";
+                }else if(e.location==2){
+                    posi="right";
+                }
+                if($('body:first>#manualblock'+posi).length==0){
+                    $('<div id="manualblock'+posi+'" class="manualblock"></div>').appendTo('body');
+                    $('body:first>#manualblock'+posi).html('&nbsp;')
+                        .css("position","absolute")
+                        .css("height","5px")
+                        .css("width","5px")
+                        .css("bottom",0)
+                        .css(posi,0)
+                        .css("background-color","magenta")
+                        .css("z-index",20)
+                    ;
+                }
             }
         }
     },true);
     window.addEventListener("keyup",function(e){
-        if(e.keyCode==17&&e.location==2){
+        if(e.keyCode==17){
             if(cmblockcd==0){
             }else if(cmblockcd==1.72){
                 cmblockcd=0.71;
             }else if(cmblockcd==-1.73){
                 cmblockcd=-0.74;
             }
+            var posi="";
+            if(e.location==1){
+                posi="left";
+            }else if(e.location==2){
+                posi="right";
+            }
+            $('body:first>#manualblock'+posi).remove();
         }
     },true);
+    $(EXfootcome).on("mousemove",usereventFCMousemove);
+    $(EXfootcome).on("mouseout",usereventFCMouseout);
 console.log("setOptionEvent ok");
 }
 function startCM(){
@@ -1878,8 +1980,10 @@ chrome.runtime.onMessage.addListener(function(r){
                 if(EXfootcome&&$(EXfootcome).next('#timerthird').length>0){
                     $(EXfootcome).next('#timerthird').text('CM');
                 }
-                cmblockcd=0;
-                startCM();
+                if(cmblockcd!=1.72&&cmblockcd!=0.71){
+                    cmblockcd=0;
+                    startCM();
+                }
             }
         }else if(r.value[1]==r.value[2]){
             if(bginfo[1].length>0&&r.value[0]==bginfo[1][0]){
@@ -1892,8 +1996,10 @@ chrome.runtime.onMessage.addListener(function(r){
                     if(EXfootcome&&$(EXfootcome).next('#timerthird').length>0&&bginfo[0]>0){
                         $(EXfootcome).next('#timerthird').html('&nbsp;');
                     }
-                    cmblockcd=0;
-                    endCM();
+                    if(cmblockcd!=-1.73&&cmblockcd!=-0.74){
+                        cmblockcd=0;
+                        endCM();
+                    }
                 }else{
 //console.log("tryCM bginfo[2]= "+bginfo[2]);
                     setTimeout(tryCM,500);

--- a/onairpage.js
+++ b/onairpage.js
@@ -1357,15 +1357,15 @@ function usereventFCMouseout(){
         .css("background-color","")
     ;
     $('body:first>#manualblockrd').remove();
-    if(cmblockcd*100%100==62){
-        cmblockcd=0.61;
+    if(cmblockcd*100%100==63){
+        cmblockcd=0.63;
     }else if(cmblockcd*100%100==-63){
-        cmblockcd=-0.64;
+        cmblockcd=-0.63;
     }
 }
 function finishFCbgColored(){
     if(cmblockcd>0){
-        cmblockcd=299.62;
+        cmblockcd=299.63;
     }else if(cmblockcd<0){
         cmblockcd=-299.63;
     }
@@ -1405,12 +1405,12 @@ function chkFCbgc(retrycount){
 }
 function usereventFCMousemove(){
     if(!EXfootcome){return;}
-    if(cmblockcd!=0&&$('body:first>#manualblockrd').length==0){
-        if($(EXfootcome).css("transition")!="background-color 1s linear 0s"){
-            $(EXfootcome).css("transition","background-color 1s linear 0s")
+    if(cmblockcd!=0&&Math.abs(cmblockcd*100%100)!=63){
+        if($(EXfootcome).css("transition")!="background-color 1.2s linear 0s"){
+            $(EXfootcome).css("transition","background-color 1.2s linear 0s")
                 .css("background-color","rgb(255, 0, 255)")
             ;
-            setTimeout(chkFCbgc,1000,10);
+            setTimeout(chkFCbgc,1200,5);
         }
         if(isFCbgColored()){
             finishFCbgColored();
@@ -1498,7 +1498,7 @@ console.log("dblclick");
         }else if(e.keyCode==17){ //17ctrl
             if(cmblockcd!=0){
                 if(cmblockcd>0){
-                    cmblockcd=1.72;
+                    cmblockcd=1.73;
                 }else if(cmblockcd<0){
                     cmblockcd=-1.73;
                 }
@@ -1526,10 +1526,10 @@ console.log("dblclick");
     window.addEventListener("keyup",function(e){
         if(e.keyCode==17){
             if(cmblockcd==0){
-            }else if(cmblockcd==1.72){
-                cmblockcd=0.71;
+            }else if(cmblockcd==1.73){
+                cmblockcd=0.73;
             }else if(cmblockcd==-1.73){
-                cmblockcd=-0.74;
+                cmblockcd=-0.73;
             }
             var posi="";
             if(e.location==1){
@@ -1980,7 +1980,7 @@ chrome.runtime.onMessage.addListener(function(r){
                 if(EXfootcome&&$(EXfootcome).next('#timerthird').length>0){
                     $(EXfootcome).next('#timerthird').text('CM');
                 }
-                if(cmblockcd!=1.72&&cmblockcd!=0.71&&cmblockcd*100%100!=62&&cmblockcd!=0.61){
+                if(cmblockcd*100%100!=73&&cmblockcd*100%100!=63){
                     cmblockcd=0;
                     startCM();
                 }
@@ -1996,7 +1996,7 @@ chrome.runtime.onMessage.addListener(function(r){
                     if(EXfootcome&&$(EXfootcome).next('#timerthird').length>0&&bginfo[0]>0){
                         $(EXfootcome).next('#timerthird').html('&nbsp;');
                     }
-                    if(cmblockcd!=-1.73&&cmblockcd!=-0.74&&cmblockcd*100%100!=-63&&cmblockcd!=-0.64){
+                    if(cmblockcd*100%100!=-73&&cmblockcd*100%100!=-63){
                         cmblockcd=0;
                         endCM();
                     }

--- a/onairpage.js
+++ b/onairpage.js
@@ -1351,16 +1351,24 @@ function usereventVolMouseout(){
     if(!EXside){return;}
     $(EXside).css("transform","translate(0px,-50%)");
 }
-function usereventFCMouseout(){
+//function usereventFCMouseout(){
+function usereventFCMouseleave(){
+//console.log("ueFCMouseleave");
     if(!EXfootcome){return;}
     $(EXfootcome).css("transition","")
         .css("background-color","")
     ;
-    $('body:first>#manualblockrd').remove();
+//    $('body:first>#manualblockrd').remove();
+    $('body:first>.manualblock').remove();
+//    if($('body:first>.manualblock').length==0){
+    $('body').css("overflow-y","");
+//    }
     if(cmblockcd*100%100==63){
-        cmblockcd=0.63;
+        bginfo[3]=2;
+        startCM();
     }else if(cmblockcd*100%100==-63){
-        cmblockcd=-0.63;
+        bginfo[3]=0;
+        endCM(true);
     }
 }
 function finishFCbgColored(){
@@ -1373,6 +1381,7 @@ function finishFCbgColored(){
         .css("background-color","")
     ;
     if($('body:first>#manualblockrd').length==0){
+        $('body').css("overflow-y","hidden");
         $('<div id="manualblockrd" class="manualblock"></div>').appendTo('body');
         $('body:first>#manualblockrd').html('&nbsp;')
             .css("position","absolute")
@@ -1386,6 +1395,7 @@ function finishFCbgColored(){
     }
 }
 function isFCbgColored(){
+    if(Math.abs(cmblockcd*100%100)==63){return true;}
     if(!EXfootcome){return false;}
     var re=/^rgba?\( *(\d+) *, *(\d+) *, *(\d+) *(?:, *(\d+) *)?\)$/;
     var tar=$(EXfootcome).css("background-color");
@@ -1404,6 +1414,7 @@ function chkFCbgc(retrycount){
     }
 }
 function usereventFCMousemove(){
+//console.log("ueFCMousemove");
     if(!EXfootcome){return;}
     if(cmblockcd!=0&&Math.abs(cmblockcd*100%100)!=63){
         if($(EXfootcome).css("transition")!="background-color 1.2s linear 0s"){
@@ -1509,6 +1520,7 @@ console.log("dblclick");
                     posi="right";
                 }
                 if($('body:first>#manualblock'+posi).length==0){
+                    $('body').css("overflow-y","hidden");
                     $('<div id="manualblock'+posi+'" class="manualblock"></div>').appendTo('body');
                     $('body:first>#manualblock'+posi).html('&nbsp;')
                         .css("position","absolute")
@@ -1526,10 +1538,12 @@ console.log("dblclick");
     window.addEventListener("keyup",function(e){
         if(e.keyCode==17){
             if(cmblockcd==0){
-            }else if(cmblockcd==1.73){
-                cmblockcd=0.73;
-            }else if(cmblockcd==-1.73){
-                cmblockcd=-0.73;
+            }else if(cmblockcd*100%100==73){
+                bginfo[3]=2;
+                startCM();
+            }else if(cmblockcd*100%100==-73){
+                bginfo[3]=0;
+                endCM(true);
             }
             var posi="";
             if(e.location==1){
@@ -1537,21 +1551,28 @@ console.log("dblclick");
             }else if(e.location==2){
                 posi="right";
             }
-            $('body:first>#manualblock'+posi).remove();
+//            $('body:first>#manualblock'+posi).remove();
+            $('body:first>.manualblock').remove();
+//            if($('body:first>.manualblock').length==0){
+            $('body').css("overflow-y","");
+//            }
         }
     },true);
     $(EXfootcome).on("mousemove",usereventFCMousemove);
-    $(EXfootcome).on("mouseout",usereventFCMouseout);
+//    $(EXfootcome).on("mouseout",usereventFCMouseout);
+    $(EXfootcome).on("mouseleave",usereventFCMouseleave);
 console.log("setOptionEvent ok");
 }
 function startCM(){
 console.log("startCM");
+    cmblockcd=0;
     if(isCMBlack){screenBlackSet(isCMBkTrans?1:3);}
     if(isCMsoundoff){soundSet(false);}
     if(CMsmall<100){movieZoomOut(1);}
 }
 function endCM(sw){
 console.log("endCM");
+    cmblockcd=0;
     if(sw||bginfo[1].length==0){
         if(isCMBlack){screenBlackSet(0);}
         if(isCMsoundoff){soundSet(true);}
@@ -1561,7 +1582,6 @@ console.log("endCM");
 function tryCM(){
     if(bginfo[1].length==0){
         bginfo[2]=0;
-        cmblockcd=0;
         endCM();
     }
 }
@@ -1706,14 +1726,12 @@ $(window).on('load', function () {
             if(cmblockcd>0){
                 cmblockcd-=1;
                 if(cmblockcd<=0){
-                    cmblockcd=0;
                     bginfo[3]=2;
                     startCM();
                 }
             }else{
                 cmblockcd+=1;
                 if(cmblockcd>=0){
-                    cmblockcd=0;
                     bginfo[3]=0;
                     endCM(true);
                 }
@@ -1980,8 +1998,7 @@ chrome.runtime.onMessage.addListener(function(r){
                 if(EXfootcome&&$(EXfootcome).next('#timerthird').length>0){
                     $(EXfootcome).next('#timerthird').text('CM');
                 }
-                if(cmblockcd*100%100!=73&&cmblockcd*100%100!=63){
-                    cmblockcd=0;
+                if(cmblockcd*100%10!=3){
                     startCM();
                 }
             }
@@ -1996,8 +2013,7 @@ chrome.runtime.onMessage.addListener(function(r){
                     if(EXfootcome&&$(EXfootcome).next('#timerthird').length>0&&bginfo[0]>0){
                         $(EXfootcome).next('#timerthird').html('&nbsp;');
                     }
-                    if(cmblockcd*100%100!=-73&&cmblockcd*100%100!=-63){
-                        cmblockcd=0;
+                    if(cmblockcd*100%10!=-3){
                         endCM();
                     }
                 }else{


### PR DESCRIPTION
//マウスで判定待機中になってもctrlで発動可能
//手動による判定待機中はwebrequest支援も無視して手動の待機を優先し、自動では発動しない。
//なのでキーとマウスから離れた状態で、カーソル位置のせいで判定待機になってしまった場合、
//積極的にキーかマウスを操作する必要がある。