### PR TITLE
Patch 1

### DIFF
--- a/event.js
+++ b/event.js
@@ -142,10 +142,13 @@ chrome.runtime.onMessage.addListener(function(request, sender, sendResponse) {
             });
         });
     } else if (request.type === "windowresize"){
-        chrome.windows.getCurrent(function(w){
+        chrome.windows.get(sender.tab.windowId,function(w){
             chrome.windows.update(w.id,{width:(w.width+request.valw),height:(w.height+request.valh)});
-            sendResponse(0);
         });
+        sendResponse(0);
+    } else if (request.type === "tabsoundplaystop"){
+        chrome.tabs.update(sender.tab.id,{muted:request.valb});
+        sendResponse(0);
     } else {
         console.warn("message type not match", request.type);
     }

--- a/onairpage.js
+++ b/onairpage.js
@@ -299,7 +299,8 @@ function putComeArray(inp){
 
         //コメント設置位置の保持
         //コメント右端が画面右端に出てくるまでの時間を保持する
-        comeLatestPosi.push([inp[i][1],Math.min(comeTTLmax,Math.max(comeTTLmin,Math.floor(settings.movingCommentSecond*(mcleft+mcwidth-winwidth)/(winwidth+mcwidth))))]);
+        var r=settings.movingCommentSecond*(mcleft+mcwidth-winwidth)/(winwidth+mcwidth);
+        comeLatestPosi.push([inp[i][1],Math.min(comeTTLmax,Math.max(comeTTLmin,2+Math.ceil(r)))]);
         comeLatestPosi.shift();
 
         var waitsec=settings.movingCommentSecond*(mcleft+mcwidth)/(winwidth+mcwidth);

--- a/option.js
+++ b/option.js
@@ -16,69 +16,6 @@ $(function(){
       .css("display","flex")
       .css("flex-direction","column")
     ;
-    if($('#settingsArea #CommentMukouSettings .setTables').length==0){
-        $('#settingsArea #CommentMukouSettings').wrapInner('<div id="ComeMukouD">');
-        $('<div id="ComeMukouO" class="setTables">コメント数が表示されないとき</div>').prependTo('#settingsArea #CommentMukouSettings');
-        $('#settingsArea #ComeMukouO').css("margin-top","8px")
-            .css("padding","8px")
-            .css("border","1px solid black")
-        ;
-        $('<table id="setTable">').appendTo('#settingsArea #ComeMukouO');
-        $('#settingsArea table#setTable').css("border-collapse","collapse");
-        $('<tr><th></th><th colspan=2>画面真っ黒</th><th>画面縮小</th><th>音量ミュート</th></tr>').appendTo('#settingsArea table#setTable');
-        $('<tr><td>適用</td><td></td><td></td><td></td><td></td></tr>').appendTo('#settingsArea table#setTable');
-        $('<tr><td>画面クリックで<br>解除・再適用</td><td colspan=2></td><td></td><td></td></tr>').appendTo('#settingsArea table#setTable');
-        $('#settingsArea #isCMBlack').appendTo('#settingsArea table#setTable tr:eq(1)>td:eq(1)');
-        $('#settingsArea #isCMBkTrans').appendTo('#settingsArea table#setTable tr:eq(1)>td:eq(1)').css("display","none");
-        $('<input type="radio" name="cmbktype" value=0>').appendTo('#settingsArea table#setTable tr:eq(1)>td:eq(2)')
-            .after("全面真黒<br>")
-        ;
-        $('<input type="radio" name="cmbktype" value=1>').appendTo('#settingsArea table#setTable tr:eq(1)>td:eq(2)')
-            .after("下半透明")
-        ;
-        $('#settingsArea input[type="radio"][name="cmbktype"]').prop("disabled",!isCMBlack)
-            .val([isCMBkTrans?1:0])
-        ;
-        $('#settingsArea table#setTable input[type="radio"][name="cmbktype"]').change(setCMBKChangedR);
-        $('#settingsArea #CMsmall').appendTo('#settingsArea table#setTable tr:eq(1)>td:eq(3)').after("％")
-            .css("text-align","right")
-            .css("width","4em")
-        ;
-        $('#settingsArea #isCMsoundoff').appendTo('#settingsArea table#setTable tr:eq(1)>td:eq(4)');
-        $('#settingsArea table#setTable #isCMBlack').change(setCMBKChangedB);
-        $('#settingsArea table#setTable #CMsmall').change(setCMzoomChangedR);
-        $('#settingsArea table#setTable #isCMsoundoff').change(setCMsoundChangedB);
-        $('#settingsArea #isCMBkR').appendTo('#settingsArea table#setTable tr:eq(2)>td:eq(1)');
-        $('#settingsArea #isCMsmlR').appendTo('#settingsArea table#setTable tr:eq(2)>td:eq(2)');
-        $('#settingsArea #isCMsoundR').appendTo('#settingsArea table#setTable tr:eq(2)>td:eq(3)');
-        $('#settingsArea table#setTable td').css("border","1px solid black")
-            .css("text-align","center")
-            .css("padding","3px")
-        ;
-        $('#settingsArea table#setTable tr:eq(1)>td:eq(1)').css("border-right","none");
-        $('#settingsArea table#setTable tr:eq(1)>td:eq(2)').css("border-left","none")
-            .css("text-align","left")
-        ;
-        $('<div id="ComeMukouW" class="setTables">↑の実行待機(秒)</div>').insertAfter('#settingsArea #ComeMukouO');
-        $('#settingsArea #ComeMukouW').css("margin-top","8px")
-            .css("padding","8px")
-            .css("border","1px solid black")
-        ;
-        $('#settingsArea #beforeCMWait').appendTo('#settingsArea #ComeMukouW')
-            .before("　開始後")
-        ;
-        $('#settingsArea #afterCMWait').appendTo('#settingsArea #ComeMukouW')
-            .before("　終了後")
-            .after("<br>待機時間中、押している間は実行せず、離すと即実行するキー<br>")
-        ;
-        $('#settingsArea #isManualKeyCtrlL').appendTo('#settingsArea #ComeMukouW').after("左ctrl");
-        $('#settingsArea #isManualKeyCtrlR').appendTo('#settingsArea #ComeMukouW').after("右ctrl");
-        $('#settingsArea #isManualMouseBR').appendTo('#settingsArea #ComeMukouW')
-            .before("<br>待機時間中、カーソルを合わせている間は実行せず、外すと即実行する場所<br>")
-            .after("右下のコメント数表示部")
-        ;
-        $('#settingsArea #ComeMukouD').remove();
-    }
     chrome.storage.local.get(function (value) {
         var isResizeScreen = value.resizeScreen || false;
         console.log(value.movingCommentLimit)
@@ -125,6 +62,7 @@ $(function(){
         var isCMBkR = (value.CMBkR || false)&&isCMBlack;
         var isCMsoundR = (value.CMsoundR || false)&&isCMsoundoff;
         var isCMsmlR = (value.CMsmlR || false)&&(CMsmall!=100);
+        var isTabSoundplay = value.tabSoundplay || false;
         $("#isResizeScreen").prop("checked", isResizeScreen);
         $("#isDblFullscreen").prop("checked", isDblFullscreen);
         $("#isEnterSubmit").prop("checked", isEnterSubmit);
@@ -182,7 +120,86 @@ $(function(){
         $("#isCMBkR").prop("checked", isCMBkR);
         $("#isCMsoundR").prop("checked", isCMsoundR);
         $("#isCMsmlR").prop("checked", isCMsmlR);
+        $("#isTabSoundplay").prop("checked", isTabSoundplay);
     });
+    if($('#settingsArea #CommentMukouSettings .setTables').length==0){
+        $('#settingsArea #CommentMukouSettings').wrapInner('<div id="ComeMukouD">');
+        $('<div id="ComeMukouO" class="setTables">コメント数が表示されないとき</div>').prependTo('#settingsArea #CommentMukouSettings');
+        $('#settingsArea #ComeMukouO').css("margin-top","8px")
+            .css("padding","8px")
+            .css("border","1px solid black")
+        ;
+        $('<table id="setTable">').appendTo('#settingsArea #ComeMukouO');
+        $('#settingsArea table#setTable').css("border-collapse","collapse");
+        $('<tr><th></th><th colspan=2>画面真っ黒</th><th>画面縮小</th><th colspan=2>音量ミュート</th></tr>').appendTo('#settingsArea table#setTable');
+        $('<tr><td>適用</td><td></td><td></td><td></td><td></td><td></td></tr>').appendTo('#settingsArea table#setTable');
+        $('<tr><td>画面クリックで<br>解除・再適用</td><td colspan=2></td><td></td><td colspan=2></td></tr>').appendTo('#settingsArea table#setTable');
+
+        $('#settingsArea #isCMBlack').appendTo('#settingsArea table#setTable tr:eq(1)>td:eq(1)');
+        $('#settingsArea #isCMBkTrans').appendTo('#settingsArea table#setTable tr:eq(1)>td:eq(1)').css("display","none");
+        $('<input type="radio" name="cmbktype" value=0>').appendTo('#settingsArea table#setTable tr:eq(1)>td:eq(2)')
+            .after("全面真黒<br>")
+        ;
+        $('<input type="radio" name="cmbktype" value=1>').appendTo('#settingsArea table#setTable tr:eq(1)>td:eq(2)')
+            .after("下半透明")
+        ;
+        $('#settingsArea table#setTable input[type="radio"][name="cmbktype"]').change(setCMBKChangedR);
+
+        $('#settingsArea #CMsmall').appendTo('#settingsArea table#setTable tr:eq(1)>td:eq(3)').after("％")
+            .css("text-align","right")
+            .css("width","4em")
+        ;
+
+        $('#settingsArea #isCMsoundoff').appendTo('#settingsArea table#setTable tr:eq(1)>td:eq(4)');
+        $('#settingsArea #isTabSoundplay').appendTo('#settingsArea table#setTable tr:eq(1)>td:eq(4)').css("display","none");
+        $('<input type="radio" name="cmsotype" value=0>').appendTo('#settingsArea table#setTable tr:eq(1)>td:eq(5)')
+            .after("プレイヤー<br>")
+        ;
+        $('<input type="radio" name="cmsotype" value=1>').appendTo('#settingsArea table#setTable tr:eq(1)>td:eq(5)')
+            .after("タブ設定")
+        ;
+        $('#settingsArea table#setTable input[type="radio"][name="cmsotype"]').change(setCMsoundChangedR);
+
+        $('#settingsArea table#setTable #isCMBlack').change(setCMBKChangedB);
+        $('#settingsArea table#setTable #CMsmall').change(setCMzoomChangedR);
+        $('#settingsArea table#setTable #isCMsoundoff').change(setCMsoundChangedB);
+        $('#settingsArea #isCMBkR').appendTo('#settingsArea table#setTable tr:eq(2)>td:eq(1)');
+        $('#settingsArea #isCMsmlR').appendTo('#settingsArea table#setTable tr:eq(2)>td:eq(2)');
+        $('#settingsArea #isCMsoundR').appendTo('#settingsArea table#setTable tr:eq(2)>td:eq(3)');
+        $('#settingsArea table#setTable td').css("border","1px solid black")
+            .css("text-align","center")
+            .css("padding","3px")
+        ;
+        $('#settingsArea table#setTable tr:eq(1)>td:eq(1)').css("border-right","none");
+        $('#settingsArea table#setTable tr:eq(1)>td:eq(2)').css("border-left","none")
+            .css("text-align","left")
+        ;
+        $('#settingsArea table#setTable tr:eq(1)>td:eq(4)').css("border-right","none");
+        $('#settingsArea table#setTable tr:eq(1)>td:eq(5)').css("border-left","none")
+            .css("text-align","left")
+        ;
+
+        $('<div id="ComeMukouW" class="setTables">↑の実行待機(秒)</div>').insertAfter('#settingsArea #ComeMukouO');
+        $('#settingsArea #ComeMukouW').css("margin-top","8px")
+            .css("padding","8px")
+            .css("border","1px solid black")
+        ;
+        $('#settingsArea #beforeCMWait').appendTo('#settingsArea #ComeMukouW')
+            .before("　開始後")
+        ;
+        $('#settingsArea #afterCMWait').appendTo('#settingsArea #ComeMukouW')
+            .before("　終了後")
+            .after("<br>待機時間中、押している間は実行せず、離すと即実行するキー<br>")
+        ;
+        $('#settingsArea #isManualKeyCtrlL').appendTo('#settingsArea #ComeMukouW').after("左ctrl");
+        $('#settingsArea #isManualKeyCtrlR').appendTo('#settingsArea #ComeMukouW').after("右ctrl");
+        $('#settingsArea #isManualMouseBR').appendTo('#settingsArea #ComeMukouW')
+            .before("<br>待機時間中、カーソルを1秒以上連続で合わせている間は実行せず、外すと即実行する場所<br>")
+            .after("右下のコメント数表示部")
+        ;
+        $('#settingsArea #ComeMukouD').remove();
+        setTimeout(radiodelayset,50);
+    }
     $("#saveBtn").click(function () {
         chrome.storage.local.set({
             "resizeScreen": $("#isResizeScreen").prop("checked"), 
@@ -228,7 +245,8 @@ $(function(){
             "manualMouseBR": $("#isManualMouseBR").prop("checked"),
             "CMBkR": $("#isCMBkR").prop("checked")&&$("#isCMBlack").prop("checked"),
             "CMsoundR": $("#isCMsoundR").prop("checked")&&$("#isCMsoundoff").prop("checked"),
-            "CMsmlR": $("#isCMsmlR").prop("checked")&&(parseInt($("#CMsmall").val())!=100)
+            "CMsmlR": $("#isCMsmlR").prop("checked")&&(parseInt($("#CMsmall").val())!=100),
+            "tabSoundplay": $("#isTabSoundplay").prop("checked")
         }, function () {
             $("#info").show().text("設定保存しました").fadeOut(4000);
         });
@@ -273,6 +291,7 @@ function setCMzoomChangedR(){
     }
 }
 function setCMsoundChangedB(){
+    $('#settingsArea input[type="radio"][name="cmsotype"]').prop("disabled",!$("#isCMsoundoff").prop("checked"));
     $('#settingsArea #isCMsoundR').prop("checked",false)
         .prop("disabled",!$("#isCMsoundoff").prop("checked"))
     ;
@@ -285,4 +304,15 @@ function setCMBKChangedB(){
 }
 function setCMBKChangedR(){
     $('#settingsArea #isCMBkTrans').prop("checked",$('#settingsArea input[type="radio"][name="cmbktype"]:checked').val()==1?true:false);
+}
+function setCMsoundChangedR(){
+    $('#settingsArea #isTabSoundplay').prop("checked",$('#settingsArea input[type="radio"][name="cmsotype"]:checked').val()==1?true:false);
+}
+function radiodelayset(){
+    $('#settingsArea input[type="radio"][name="cmbktype"]').prop("disabled",!$("#isCMBlack").prop("checked"))
+        .val([$("#isCMBkTrans").prop("checked")?1:0])
+    ;
+    $('#settingsArea input[type="radio"][name="cmsotype"]').prop("disabled",!$("#isCMsoundoff").prop("checked"))
+        .val([$("#isTabSoundplay").prop("checked")?1:0])
+    ;
 }

--- a/option.js
+++ b/option.js
@@ -2,20 +2,42 @@ $(function(){
     $("#settingsArea").html(generateOptionHTML(true));
     $("#CommentMukouSettings").hide();
     $("#CommentColorSettings").css("width","600px")
-      .css("background-color","darkgreen")
-      .css("padding","8px")
-      .children('div').css("clear","both")
-      .children('span.desc').css("padding","0px 4px")
-      .next('span.prop').css("background-color","white")
-      .css("padding","0px 4px")
-      .next('input[type="range"]').css("float","right")
+        .css("background-color","darkgreen")
+        .css("padding","8px")
+        .children('div').css("clear","both")
+        .children('span.desc').css("padding","0px 4px")
+        .next('span.prop').css("background-color","white")
+        .css("padding","0px 4px")
+        .next('input[type="range"]').css("float","right")
     ;
     $("#itimePosition").insertBefore("#isTimeVisible+*")
-      .css("border","black solid 1px")
-      .css("margin-left","16px")
-      .css("display","flex")
-      .css("flex-direction","column")
+        .css("border","black solid 1px")
+        .css("margin-left","16px")
+        .css("display","flex")
+        .css("flex-direction","column")
+        .children().css("display","flex")
+        .css("flex-direction","row")
+        .css("margin","1px 0px")
+        .children().css("margin-left","4px")
     ;
+    $("#iprotitlePosition").insertBefore("#isProtitleVisible+*")
+        .css("border","black solid 1px")
+        .css("margin-left","16px")
+        .css("display","flex")
+        .css("flex-direction","column")
+        .children().css("display","flex")
+        .css("flex-direction","row")
+        .css("margin","1px 0px")
+        .children().css("margin-left","4px")
+    ;
+    $("#iproSamePosition").insertBefore("#isProtitleVisible")
+        .css("border","black solid 1px")
+        .children().css("display","flex")
+        .css("flex-direction","row")
+        .css("margin","1px 0px")
+        .children().css("margin-left","4px")
+    ;
+    $('<span style="margin-left:4px;">↑と↓が同じ位置の場合: </span>').prependTo("#iproSamePosition>*");
     chrome.storage.local.get(function (value) {
         var isResizeScreen = value.resizeScreen || false;
         console.log(value.movingCommentLimit)
@@ -63,6 +85,10 @@ $(function(){
         var isCMsoundR = (value.CMsoundR || false)&&isCMsoundoff;
         var isCMsmlR = (value.CMsmlR || false)&&(CMsmall!=100);
         var isTabSoundplay = value.tabSoundplay || false;
+        var isOpenPanelwCome=value.openPanelwCome||false;
+        var isProtitleVisible=value.protitleVisible||false;
+        var protitlePosition=value.protitlePosition||"windowtopleft";
+        var proSamePosition=value.proSamePosition||"over";
         $("#isResizeScreen").prop("checked", isResizeScreen);
         $("#isDblFullscreen").prop("checked", isDblFullscreen);
         $("#isEnterSubmit").prop("checked", isEnterSubmit);
@@ -121,6 +147,10 @@ $(function(){
         $("#isCMsoundR").prop("checked", isCMsoundR);
         $("#isCMsmlR").prop("checked", isCMsmlR);
         $("#isTabSoundplay").prop("checked", isTabSoundplay);
+        $("#isOpenPanelwCome").prop("checked",isOpenPanelwCome);
+        $("#isProtitleVisible").prop("checked",isProtitleVisible);
+        $('#iprotitlePosition [type="radio"][name="protitlePosition"]').val([protitlePosition]);
+        $('#iproSamePosition [type="radio"][name="proSamePosition"]').val([proSamePosition]);
     });
     if($('#settingsArea #CommentMukouSettings .setTables').length==0){
         $('#settingsArea #CommentMukouSettings').wrapInner('<div id="ComeMukouD">');
@@ -246,7 +276,11 @@ $(function(){
             "CMBkR": $("#isCMBkR").prop("checked")&&$("#isCMBlack").prop("checked"),
             "CMsoundR": $("#isCMsoundR").prop("checked")&&$("#isCMsoundoff").prop("checked"),
             "CMsmlR": $("#isCMsmlR").prop("checked")&&(parseInt($("#CMsmall").val())!=100),
-            "tabSoundplay": $("#isTabSoundplay").prop("checked")
+            "tabSoundplay": $("#isTabSoundplay").prop("checked"),
+            "openPanelwCome":$("#isOpenPanelwCome").prop("checked"),
+            "protitleVisible":$("#isProtitleVisible").prop("checked"),
+            "protitlePosition":$('#iprotitlePosition [name="protitlePosition"]:checked').val(),
+            "proSamePosition":$('#iproSamePosition [name="proSamePosition"]:checked').val()
         }, function () {
             $("#info").show().text("設定保存しました").fadeOut(4000);
         });

--- a/settings.js
+++ b/settings.js
@@ -234,7 +234,14 @@ var CMSettingList = [
         },
         {
             "name": "isCMsoundoff",
-            "description": "コメント数が表示されないとき音量ミュート",
+//            "description": "コメント数が表示されないとき音量ミュート",
+            "description": "コメント数が表示されないときプレイヤーの音量ミュート",
+            "type": "boolean",
+            "isInstantChangable": true
+        },
+        {
+            "name": "isTabSoundplay",
+            "description": "↑をプレイヤーでなくchromeタブ設定でミュートにする",
             "type": "boolean",
             "isInstantChangable": true
         },

--- a/settings.js
+++ b/settings.js
@@ -44,10 +44,11 @@ var settingsList = [
     },
     {
         "name": "isMoveByCSS",
-        "description": "コメントをCSSのtransitionで流す(速度も変更できます。コメント流しが重い場合、これで軽減するかもしれません。)",
+//        "description": "コメントをCSSのtransitionで流す(速度も変更できます。コメント流しが重い場合、これで軽減するかもしれません。)",
+        "description": "コメントをCSSのtransitionで流す(速度も変更できます。コメント流しが重い場合、これで軽減するかもしれません。)※現在このオプションは強制的に有効として扱っています",
         "type": "boolean",
-//        "isInstantChangable": false
-        "isInstantChangable": true
+        "isInstantChangable": false
+//        "isInstantChangable": true
     },
     {
         "name": "isComeNg",
@@ -113,6 +114,12 @@ var settingsList = [
         "isInstantChangable": true
     },
     {
+        "name": "isProtitleVisible",
+        "description": "番組タイトルを表示",
+        "type": "boolean",
+        "isInstantChangable": true
+    },
+    {
         "name": "isSureReadComment",
         "description": "常にコメント欄を表示する",
         "type": "boolean",
@@ -172,6 +179,12 @@ var settingsList = [
         "description": "↑既に開いている放送画面があれば新しいタブを開かずそのタブを切り替える(アクティブなタブ優先)",
         "type": "boolean",
         "isInstantChangable": false
+    },
+    {
+        "name": "isOpenPanelwCome",
+        "description": "コメント欄を開いていても黒帯パネルを表示する",
+        "type": "boolean",
+        "isInstantChangable": true
     }
     ];
 var ComeColorSettingList = [
@@ -204,13 +217,44 @@ var RadioSettingList = [
     {
         "name": "timePosition",
         "list":[
-            ["windowtop","ウィンドウの右上（常時表示）"],
-            ["windowbottom","ウィンドウの右下（常時表示）"],
-            ["commentinputtop","コメント入力の右上"],
-            ["commentinputbottom","コメント入力の右下"],
-            ["header","右上のメニューの上"],
-            ["footer","右下のコメント数の下"]
+            [["windowtop","ウィンドウの右上（常時表示）"]],
+            [["windowbottom","ウィンドウの右下（常時表示）"]],
+            [["commentinputtop","コメント入力の右上"]],
+            [["commentinputbottom","コメント入力の右下"]],
+            [["header","右上のメニューの上"]],
+            [["footer","右下のコメント数の下"]]
         ]
+    },
+    {
+        "name": "protitlePosition",
+        "list":[
+            [
+                ["windowtopleft","ウィンドウの左上（常時表示）"],
+                ["windowtopright","ウィンドウの右上（常時表示）"]
+            ],[
+                ["windowbottomleft","ウィンドウの左下（常時表示）"],
+                ["windowbottomright","ウィンドウの右下（常時表示）"]
+            ],[
+                ["commentinputtopleft","コメント入力の左上"],
+                ["commentinputtopright","コメント入力の右上"]
+            ],[
+                ["commentinputbottomleft","コメント入力の左下"],
+                ["commentinputbottomright","コメント入力の右下"]
+            ],[
+                ["headerleft","左上のアイコンの上"],
+                ["headerright","右上のメニューの上"]
+            ],[
+                ["footerleft","左下のアイコンの下"],
+                ["footerright","右下のコメント数の下"]
+            ]
+        ]
+    },{
+        "name": "proSamePosition",
+        "list":[[
+                ["over","重ねる"],
+                ["vertical","縦(コメ入力欄周辺で無効)"],
+                ["horizontal","横(同)"]
+            ]]
     }
     ];
 var CMSettingList = [
@@ -347,8 +391,12 @@ function generateRadioInput(settingsArr){
         inputHTML+='<div id="i'+settingsArr[i].name+'">';
         for(var j=0;j<settingsArr[i].list.length;j++){
             inputHTML+='<div>';
-            inputHTML+='<input type="radio" name="'+settingsArr[i].name+'" value="'+settingsArr[i].list[j][0]+'">';
-            inputHTML+=settingsArr[i].list[j][1];
+            for(var k=0;k<settingsArr[i].list[j].length;k++){
+                inputHTML+='<div>';
+                inputHTML+='<input type="radio" name="'+settingsArr[i].name+'" value="'+settingsArr[i].list[j][k][0]+'">';
+                inputHTML+=settingsArr[i].list[j][k][1];
+                inputHTML+='</div>';
+            }
             inputHTML+='</div>';
         }
         inputHTML+='</div>';


### PR DESCRIPTION
//新着コメントが流れるまでのギャップを無くすため、横座標のランダム化を止めた
//新着コメ個々でなく纏めて追加・削除するようにした（処理が軽減するはず）
//ためしにCSSによる流しオプションをデフォルトとした（オプションによらずCSS流し処理）
//「コメントが画面を流れる秒数」どおりの時間だけ表示するようにしたところ、
//長いコメントが特に速くなってしまったので補正をかけた
//番組名と残り時間表示の処理がかなりテキトウではあるが一応実装
//文字が小さいのは何とかする予定