### PR TITLE
Patch 1

### DIFF
--- a/onairpage.css
+++ b/onairpage.css
@@ -109,6 +109,11 @@ body{
 .toast p{
     margin: 10px;
 }
+/* 音量ゲージ下部の吹き出しを下へ伸ばす */
 [class^="TVContainer__footer___"] [class^="styles__volume___"] [class^="styles__slider-container___"]:after{
     border-top-width:15px;
+}
+/* 左下からpopしてくるボタンの処理 */
+[class^="TVContainer__ad-reserve-button___"] {
+    transform:translateX(-170px);
 }

--- a/onairpage.js
+++ b/onairpage.js
@@ -1729,8 +1729,8 @@ function comemarginfix(repeatcount,inptime,inptitle,inpsame,inpbig){
         .css("margin-bottom",jcmbot)
     ;
     if(volshift){
-        $(EXvolume).css("bottom",(80+34+jfptop+jfpbot)+"px")
-            .prev('[class^="styles__full-screen___"]').css("bottom",(80+34+jfptop+jfpbot)+"px")
+        $(EXvolume).css("bottom",(80+jform.height()+jfptop+jfpbot)+"px")
+            .prev('[class^="styles__full-screen___"]').css("bottom",(80+jform.height()+jfptop+jfpbot)+"px")
         ;
     }
     if(repeatcount>0){

--- a/onairpage.js
+++ b/onairpage.js
@@ -1498,7 +1498,6 @@ function popElement(inp){
 //true,falseは見た目の変化のみで内部の開閉状態は変化しないので映像の横縮小などは変化しないはず
 //"force"なら各triggerで開こうとする（視聴中番組情報、放送中番組一覧、コメントリスト）
 //クリックによる影響（他要素の開閉やイベント）は全く考慮していない
-//音量ボタン等の高さ位置はここで調整
     var comefix=false;
     if(inp.head!==undefined){
         comefix=true;
@@ -1575,6 +1574,7 @@ function comemarginfix(repeatcount,inptime,inptitle,inpsame,inpbig){
 //黒帯パネルとコメント欄が重なるのを防ぎ
 //番組残り時間とタイトルの分を考慮して入力欄周辺とコメ欄端のmarginを設定する
 //再試行はヘッダとフッタの開閉遅延を考慮
+//音量ボタン等の高さ位置はここで調整
     var jform=$(EXcomesend);
     var jcome=$(EXcomesend).siblings(['class^="styles__comment-list-wrapper___"']);
     var jfptop=0; //jformのpadding-top

--- a/onairpage.js
+++ b/onairpage.js
@@ -263,8 +263,8 @@ function arrayFullNgMaker(){
 function comeNG(prengcome){
     //規定のNG処理
     var ngedcome = prengcome;
-    var strface1 = "[　 ]*[Σ<＜‹૮＋\\+\\*＊･゜ﾟ:\\.｡\\'☆〜～ｗﾍ√ﾚｖꉂ꒰·‧º∑]*[　 ]*[┌└┐⊂二乁＼ヾヽつっdｄo_ƪ\\\\╭╰m👆ฅｍ\╲٩Ｏ∩┗┏]*[　 ]*[（\\(《〈\\[\\|｜fζ]+.*[8oO∀дД□◯▽△＿ڼ ౪艸^_⌣зεωm௰ｍ꒳ｰワヮ－U◇。｡࿄ш﹏㉨ꇴㅂ\\-ᴗ‿˘﹃_ﾛ◁ฅ∇益言人ㅅＡAΔΘ罒ᗜ◒◊vਊ⍛ー3xエェｪｴρｐё]+.*";
-    var strface2 = "[）\\)》〉\\]\\|｜]";
+    var strface1 = "[　 ]*[Σ<＜‹૮＋\\+\\*＊･゜ﾟ:\\.｡\\'☆〜～ｗﾍ√ﾚｖꉂ꒰·‧º∑]*[　 ]*[┌└┐⊂二乁＼ヾヽつっdｄo_ƪ\\\\╭╰m👆ฅｍ\╲٩Ｏ∩┗┏]*[　 ]*[（\\(《〈\\[\\|｜fζᔦ]+.*[8oO∀дД□◯▽△＿ڼ ౪艸^_⌣зεωm௰ｍ꒳ｰワヮ－U◇。｡࿄ш﹏㉨ꇴㅂ\\-ᴗ‿˘﹃_ﾛ◁ฅ∇益言人ㅅＡAΔΘ罒ᗜ◒◊vਊ⍛ー3xエェｪｴρｐё灬]+.*";
+    var strface2 = "[）\\)》〉\\]\\|｜ᔨ]";
     var strface3 = "[　 ]*[┐┘┌┸┓／シノ厂\\/ｼﾉ۶つっbｂoა_╮╯mｍو👎☝」Ｏσ二⊃ゝʃง╭☞∩ゞ┛︎]";
     var strface4 = "[　 ]*[彡°ﾟ\\+・･⚡\\*＋＊ﾞ゜:\\.｡\\' ̑̑🌾💢ฅ≡<＜>＞ｗﾍ√ﾚｖ꒱‧º·]*[　 ]*";
     var reface1 = new RegExp(strface1+strface2+"+"+strface3+"*"+strface4,"g");
@@ -506,20 +506,20 @@ function movieZoomOut(sw){
     }
 }
 //マウスを動かすイベント
-var movecnt = 0;
-function triggerMousemoveEvt(x, y){
-    var evt = document.createEvent("MouseEvents");
-    evt.initMouseEvent("mousemove", true, false, window, 0, 0, 0, x, y);
-    return document.dispatchEvent(evt);
-}
-function triggerMouseMoving(){
+//var movecnt = 0;
+//function triggerMousemoveEvt(x, y){
+//    var evt = document.createEvent("MouseEvents");
+//    evt.initMouseEvent("mousemove", true, false, window, 0, 0, 0, x, y);
+//    return document.dispatchEvent(evt);
+//}
+//function triggerMouseMoving(){
 //console.log('triggerMM')
-    var overlap = $('[class^="AppContainer__background-black___"]');
-    overlap.trigger('mouseover').trigger('mousemove');
-    $('body').trigger('mouseover').trigger('mousemove');
-    var xy = Math.random()*100+300;
-    triggerMousemoveEvt(xy,xy);
-}
+//    var overlap = $('[class^="AppContainer__background-black___"]');
+//    overlap.trigger('mouseover').trigger('mousemove');
+//    $('body').trigger('mouseover').trigger('mousemove');
+//    var xy = Math.random()*100+300;
+//    triggerMousemoveEvt(xy,xy);
+//}
 function openOption(sw){
     var settcontjq = $("#settcont");
     settcontjq.css("display","block");
@@ -731,7 +731,10 @@ function optionStatsUpdate(outflg){
         out=[(nww-oww),(nwh-owh)];
     }
     clearBtnColored($("#saveBtn"));
-    if(outflg){return out;}
+
+    if(outflg){return out;}else{
+        setTimeout(optionStatsUpdate,800,false);
+    }
 }
 function createSettingWindow(){
     if(!EXside){
@@ -1408,6 +1411,8 @@ function toggleCommentList(){
 //    setProSamePosiChanged();
 //}
 function hideElement(inp){
+//console.log("hideElement");
+//console.log(inp);
 //trueなら積極的に隠すよう設定
 //falseはtrueの解除(trueの設定値どおりの時のみ機能するので、積極的に表示する場合はpopElementを使用する)
 //true,falseは見た目の変化のみで内部の開閉状態は変化しないので映像の横縮小などは変化しない
@@ -1469,7 +1474,7 @@ function hideElement(inp){
         EXchli.parentElement.style.transform="translateX(100%)";
     }else if(inp.channellist==false){
         if(EXchli.parentElement.style.transform=="translateX(100%)"){
-            EXinfo.parentElement.style.transform="";
+            EXchli.parentElement.style.transform="";
         }
     }else if(inp.channellist=="force"){
         EXchli.parentElement.style.transform="translateX(100%)";
@@ -1493,11 +1498,14 @@ function hideElement(inp){
     }
 }
 function popElement(inp){
+//console.log("popElement");
+//console.log(inp);
 //trueなら積極的に表示するよう設定
 //falseはtrueの解除(trueの設定値どおりの時のみ機能するので、積極的に隠す場合はhideElementを使用する)
 //true,falseは見た目の変化のみで内部の開閉状態は変化しないので映像の横縮小などは変化しないはず
 //"force"なら各triggerで開こうとする（視聴中番組情報、放送中番組一覧、コメントリスト）
 //クリックによる影響（他要素の開閉やイベント）は全く考慮していない
+//音量ボタン等の高さ位置はここで調整
     var comefix=false;
     if(inp.head!==undefined){
         comefix=true;
@@ -1574,7 +1582,6 @@ function comemarginfix(repeatcount,inptime,inptitle,inpsame,inpbig){
 //黒帯パネルとコメント欄が重なるのを防ぎ
 //番組残り時間とタイトルの分を考慮して入力欄周辺とコメ欄端のmarginを設定する
 //再試行はヘッダとフッタの開閉遅延を考慮
-//音量ボタン等の高さ位置はここで調整
     var jform=$(EXcomesend);
     var jcome=$(EXcomesend).siblings(['class^="styles__comment-list-wrapper___"']);
     var jfptop=0; //jformのpadding-top
@@ -2722,7 +2729,7 @@ function usereventMouseover(){
     if(!settings.isAlwaysShowPanel&&(!isComeOpen()||isOpenPanelwCome)){
         if(forElementClose<4){
             forElementClose=5;
-console.log("popElement usereventMouseover");
+//console.log("popElement usereventMouseover");
             popElement({head:true,foot:true,side:true});
         }
     }
@@ -2835,6 +2842,21 @@ function usereventFCMousemove(){
             .css("background-color","")
         ;
     }
+}
+function usereventSideChliButClick(){
+//番組情報枠と被らないようにする
+    popElement({channellist:false});
+    hideElement({channellist:false});
+    hideElement({programinfo:true});
+//    $(EXchli.parentElement).css("z-index",12);
+//    $(EXinfo).css("z-index",11);
+}
+function usereventFootInfoButClick(){
+    popElement({programinfo:false});
+    hideElement({programinfo:false});
+    hideElement({channellist:true});
+//    $(EXinfo).css("z-index",12);
+//    $(EXchli.parentElement).css("z-index",11);
 }
 function setOptionEvent(){
 //自作要素のイベントは自作部分で対応
@@ -2984,6 +3006,10 @@ console.log("dblclick");
     $(EXfootcome).on("mousemove",usereventFCMousemove);
 //    $(EXfootcome).on("mouseout",usereventFCMouseout);
     $(EXfootcome).on("mouseleave",usereventFCMouseleave);
+    //放送中番組一覧を開く
+    $(EXside).contents().find('button').eq(1).on("click",usereventSideChliButClick);
+    //番組情報を開く
+    $(EXfootcome).prev().on("click",usereventFootInfoButClick);
 console.log("setOptionEvent ok");
 }
 function startCM(){

--- a/onairpage.js
+++ b/onairpage.js
@@ -49,10 +49,12 @@ var isCMBkR=false; //画面クリックによる真っ黒解除
 var isCMsoundR=false; //画面クリックによるミュート解除
 var isCMsmlR=false; //画面クリックによる縮小解除
 var isTabSoundplay=false; //タブ設定によるミュート切替
-var isOpenPanelwCome=true;
-var isProtitleVisible=false;
-var protitlePosition="windowtopleft";
-var proSamePosition="over";
+var isOpenPanelwCome=true; //コメント欄を開いてる時にもマウスオーバーで各要素を表示する
+var isProtitleVisible=false; //番組名を画面右の情報枠から取得して表示する
+var protitlePosition="windowtopleft"; //番組名の表示位置
+var proSamePosition="over"; //番組名と残り時間の位置が重なった場合の対処方法
+var isCommentWide=true;
+var isProTextLarge=true;
 
 console.log("script loaded");
 //window.addEventListener(function () {console.log})
@@ -107,6 +109,8 @@ if (chrome.storage) {
         isProtitleVisible=value.protitleVisible||false;
         protitlePosition=value.protitlePosition||protitlePosition;
         proSamePosition=value.proSamePosition||proSamePosition;
+        isCommentWide=value.commentWide||false;
+        isProTextLarge=value.proTextLarge||false;
     });
 }
 
@@ -123,15 +127,15 @@ for(var i=0;i<comeLatestLen;i++){
     comeLatestPosi[i][0]=0;
     comeLatestPosi[i][1]=comeTTLmin;
 }
-var playtick=0;
-var comeLatestCount=0;
+//var playtick=0;
+var comeLatestCount=0; //画面右下で取得するコメント数
 var arFullNg=[];
-var retrytick=[1000,3000,6000,12000,18000];
-var retrycount=0;
+//var retrytick=[1000,3000,6000,12000,18000];
+//var retrycount=0;
 var proStart = new Date(); //番組開始時刻として現在時刻を仮設定
 //var proEnd = new Date(Date.now()+60*60*1000); //番組終了として現在時刻から1時間後を仮設定
 var proEnd = new Date(); //↑で23時～24時の間に実行すると終了時刻が1日ずれるので現時刻にした
-var forElementClose = 5;
+var forElementClose = 5; //コメント表示中でも各要素を表示させた時に自動で隠す場合のカウントダウン
 var EXcomelist;
 var EXcomments;
 
@@ -163,15 +167,14 @@ var cmblockcd=0; //カウント用
 var comeRefreshing=false; //コメ欄自動開閉中はソートを実行したいのでコメント更新しない用
 var newtop = 0;//映像リサイズのtop
 var comeHealth=100; //コメント欄を開く時の初期読込時に読み込まれたコメント数（公式NGがあると100未満になる）
-var bginfo=[0,[],-1,-1];
+var bginfo=[0,[],-1,-1]; //ソースの縦長さなど主にwebrequestメッセージ入れ
 var eventAdded=false; //各イベントを1回だけ作成する用
-var setBlacked=[false,false,false];
-var keyinput = [];
+var setBlacked=[false,false,false]; //soundsetなどのスイッチ
+var keyinput = []; //コマンド入れ
 var keyCodes = "38,38,40,40,37,39,37,39,66,65";
 var comeArray=[]; //流すコメントで、新着の複数コメントのうちNG処理等を経て実際に出力するコメントのリスト
 var popElemented=false; //mouseoverでunpopElementが実行されまくるのを防止
-var proTitle="";
-//var samePosition="over";
+var proTitle="未取得"; //番組タイトル
 var proinfoOpened=false; //番組タイトルクリックで番組情報枠を開いた後にクリックで閉じれるようにする
 
 function onresize() {
@@ -260,10 +263,10 @@ function arrayFullNgMaker(){
 function comeNG(prengcome){
     //規定のNG処理
     var ngedcome = prengcome;
-    var strface1 = "[　 ]*[Σ<＜‹૮＋\\+\\*＊･゜ﾟ:\\.｡\\'☆〜～ｗﾍ√ﾚｖꉂ]*[　 ]*[┌└┐⊂二乁＼ヾヽつっdｄo_ƪ\\\\╭╰m👆ฅｍ\╲٩Ｏ∩]*[　 ]*[（\\(《〈\\[\\|｜fζ]+.*[8oO∀дД□◯▽△＿ڼ ౪艸^_⌣зεωm௰ｍ꒳ｰワヮ－U◇。｡࿄ш﹏㉨ꇴㅂ\\-ᴗ‿˘﹃_ﾛ◁ฅ∇益言人ㅅＡAΔΘ罒ᗜ◒◊vਊ⍛ー3xエェｪｴρｐ]+.*";
+    var strface1 = "[　 ]*[Σ<＜‹૮＋\\+\\*＊･゜ﾟ:\\.｡\\'☆〜～ｗﾍ√ﾚｖꉂ꒰·‧º∑]*[　 ]*[┌└┐⊂二乁＼ヾヽつっdｄo_ƪ\\\\╭╰m👆ฅｍ\╲٩Ｏ∩┗┏]*[　 ]*[（\\(《〈\\[\\|｜fζ]+.*[8oO∀дД□◯▽△＿ڼ ౪艸^_⌣зεωm௰ｍ꒳ｰワヮ－U◇。｡࿄ш﹏㉨ꇴㅂ\\-ᴗ‿˘﹃_ﾛ◁ฅ∇益言人ㅅＡAΔΘ罒ᗜ◒◊vਊ⍛ー3xエェｪｴρｐё]+.*";
     var strface2 = "[）\\)》〉\\]\\|｜]";
-    var strface3 = "[　 ]*[┐┘┌┸┓／シノ厂\\/ｼﾉ۶つっbｂoა_╮╯mｍو👎☝」Ｏσ二⊃ゝʃง∩]";
-    var strface4 = "[　 ]*[彡°ﾟ\\+・･⚡\\*＋＊ﾞ゜:\\.｡\\' ̑̑🌾💢ฅ≡<＜>＞ｗﾍ√ﾚｖ]*[　 ]*";
+    var strface3 = "[　 ]*[┐┘┌┸┓／シノ厂\\/ｼﾉ۶つっbｂoა_╮╯mｍو👎☝」Ｏσ二⊃ゝʃง╭☞∩ゞ┛︎]";
+    var strface4 = "[　 ]*[彡°ﾟ\\+・･⚡\\*＋＊ﾞ゜:\\.｡\\' ̑̑🌾💢ฅ≡<＜>＞ｗﾍ√ﾚｖ꒱‧º·]*[　 ]*";
     var reface1 = new RegExp(strface1+strface2+"+"+strface3+"*"+strface4,"g");
     var reface2 = new RegExp(strface1+strface2+"*"+strface3+"+"+strface4,"g");
     ngedcome = ngedcome.replace(reface1,"");
@@ -277,16 +280,19 @@ function comeNG(prengcome){
     ngedcome = ngedcome.replace(/[・\･…‥、\､。\｡．\.]{2,}/g,"‥");
     ngedcome = ngedcome.replace(/[　 \n]+/g," ");
     ngedcome = ngedcome.replace(/[？\?❔]+/g,"？");
-    ngedcome = ngedcome.replace(/[！\!‼️❗]+/g,"！");
+    ngedcome = ngedcome.replace(/[！\!‼️❗❗️]+/g,"！");
     ngedcome = ngedcome.replace(/[○●]+/g,"○");
+    ngedcome = ngedcome.replace(/[͜͜͏̘̣͔͙͎͎̘̜̫̗͍͚͓]+/g,"");
+    ngedcome = ngedcome.replace(/[ด็้]+/g,"");
     ngedcome = ngedcome.replace(/(.)\1{3,}/g,"$1$1$1");
     ngedcome = ngedcome.replace(/(...*?)\1{3,}/,"$1$1$1");
     ngedcome = ngedcome.replace(/(...*?)\1*(...*?)(\1|\2){2,}/g,"$1$2");
     return ngedcome;
 }
 function putComeArray(inp){
-    var mci=$('body:first>#moveContainer');
-    var mcj=$(mci).children('.movingComment');
+// inp[i]=[ commentText , commentTop , leftOffset ]
+    var mci=$('#moveContainer');
+    var mcj=mci.children('.movingComment');
     var mclen=mcj.length;
     var inplen=inp.length;
     var comeoverflowlen=inplen+mclen-movingCommentLimit;
@@ -302,14 +308,14 @@ function putComeArray(inp){
     }
     $(outxt).appendTo(mci);
 //    mclen+=inplen;
-    mcj=$(mci).children('.movingComment');
+    mcj=mci.children('.movingComment');
     mclen=mcj.length;
     for(var i=0;i<inplen;i++){
         var mck=mcj.eq(-inplen+i);
         var mcwidth=mck.width();
         var mcleft=inp[i][2]+winwidth;
         //コメント長さによって流れる速度が違いすぎるのでlogを速度計算部分に適用することで差を減らす
-        //短いコメントは設定値より少し短い時間で見えなくなる
+        //長いコメントは遅くなるので設定値より少し時間がかかる
         var mcfixedwidth=mcwidth<237?mcwidth:100*Math.floor(Math.log(mcwidth));
 
         //コメント設置位置の更新
@@ -401,7 +407,7 @@ function putComment(commentText,index,inmax) {
 //    }
     //コメント設置位置の保持
 //    comeLatestPosi.push([commentTop,Math.min(comeTTLmax,Math.max(comeTTLmin,Math.floor((commentElement.width()+maxLeftOffset)*settings.movingCommentSecond/window.innerWidth+2)))]);
-//この時点では要素長さが未確定なので暫定的
+//この時点では要素長さが未確定なので暫定的に異常値を入力してputComeArray側で拾う
     comeLatestPosi.push([commentTop,comeTTLmax+2]);
     comeLatestPosi.shift();
 //    if(parseInt($("#moveContainer").css("left"))>=1 && !isMoveByCSS){ //初期位置にいたら動かす
@@ -417,30 +423,32 @@ function putComment(commentText,index,inmax) {
 //}
 //ミュート(false)・ミュート解除(true)する関数
 function soundSet(isSound) {
+//isSound=true:音を出す
     if(isTabSoundplay){
         setBlacked[1]=!isSound;
         chrome.runtime.sendMessage({type:"tabsoundplaystop",valb:!isSound},function(r){});
         return;
     }
     if(!EXvolume){return;}
-    var butvol=$(EXvolume).contents().find('svg:first');
-    var valvol=$(EXvolume).contents().find('[class^="styles__highlighter___"]:first');
+    var volcon=$(EXvolume).contents();
+    var butvol=volcon.find('svg')[0];
+    var valvol=volcon.find('[class^="styles__highlighter___"]').height();
     var evt=document.createEvent("MouseEvents");
     evt.initEvent("click",true,true);
-    valvol=parseInt(valvol[0].style.height);
+//    valvol=parseInt(valvol[0].style.height);
     if (isSound) {
         //ミュート解除
         //音量0ならボタンを押す
         if(valvol==0){
             setBlacked[1]=false;
-            butvol[0].dispatchEvent(evt);
+            butvol.dispatchEvent(evt);
         }
     } else {
         //ミュート
         //音量0でないならボタンを押す
         if(valvol!=0){
             setBlacked[1]=true;
-            butvol[0].dispatchEvent(evt);
+            butvol.dispatchEvent(evt);
         }
     }
 }
@@ -453,20 +461,30 @@ function screenBlackSet(type) {
             .css("border-top","")
         ;
     } else if (type == 1) {
-        var w=$(window).height();
+//        var w=$(window).height();
+        var h=window.innerHeight;
         var p=0;
-        var t=1;
-        if(EXwatchingnum){
-            var jo=$(EXobli.children[EXwatchingnum]);
-            w=jo.height();
-            p=jo.offset().top;
-            if(jo.css("transform")!="none"){
-                t=parseFloat((/(?:^| )matrix\( *\d+.?\d* *, *\d+.?\d* *, *\d+.?\d* *, *(\d+.?\d*) *, *\d+.?\d* *, *\d+.?\d* *\)/.exec(jo.css("transform"))||[,t])[1]);
-            }
+//        var t=1;
+        if(EXwatchingnum!==undefined){
+//            var jo=$(EXobli.children[EXwatchingnum]);
+//            w=jo.height();
+//            p=jo.offset().top;
+//            if(jo.css("transform")!="none"){
+//                t=parseFloat((/(?:^| )matrix\( *\d+.?\d* *, *\d+.?\d* *, *\d+.?\d* *, *(\d+.?\d*) *, *\d+.?\d* *, *\d+.?\d* *\)/.exec(jo.css("transform"))||[,t])[1]);
+//            }
+//zoom後の実際に見えている大きさでheightを取得できる以下に変更
+            var eo=EXobli.children[EXwatchingnum];
+            var cr=eo.getBoundingClientRect();
+            h=cr.height;
+            p=cr.top;
+//            if(eo.style.transform.indexOf("scale")>=0){
+//                t=CMsmall/100;
+//            }
         }
         setBlacked[0]=true;
         pwaku.css("background-color","rgba(0,0,0,0.7)")
-            .css("border-top",Math.floor(p+w*t/2)+"px black solid")
+//            .css("border-top",Math.floor(p+w*t/2)+"px black solid")
+            .css("border-top",Math.floor(p+h/2)+"px black solid")
         ;
 //        pwaku[0].setAttribute("style","background-color:rgba(0,0,0,0.7);border-top-style:solid;border-top-color:black;border-top-width:"+Math.floor(p+w/2)+"px;");
     } else if (type == 2) {
@@ -478,7 +496,7 @@ function screenBlackSet(type) {
     }
 }
 function movieZoomOut(sw){
-    if(!EXwatchingnum){return;}
+    if(EXwatchingnum===undefined){return;}
     if(sw==1&&CMsmall<100){
         setBlacked[2]=true;
         $(EXobli.children[EXwatchingnum]).css("transform","scale("+CMsmall/100+")");
@@ -501,7 +519,6 @@ function triggerMouseMoving(){
     $('body').trigger('mouseover').trigger('mousemove');
     var xy = Math.random()*100+300;
     triggerMousemoveEvt(xy,xy);
-    
 }
 function openOption(sw){
     var settcontjq = $("#settcont");
@@ -551,9 +568,9 @@ function openOption(sw){
     $("#commentTextTrans").val(commentTextTrans);
     var bc="rgba("+commentBackColor+","+commentBackColor+","+commentBackColor+","+(commentBackTrans/255)+")";
     var tc="rgba("+commentTextColor+","+commentTextColor+","+commentTextColor+","+(commentTextTrans/255)+")";
-    $(EXcomelist).children('div').css("background-color",bc)
+    $(EXcomelist).children().slice(0,10).css("background-color",bc)
         .css("color",tc)
-        .children('p[class^="styles__message___"]').css("color",tc)
+        .children('[class^="styles__message___"]').css("color",tc)
     ;
     $("#commentBackColor").val(commentBackColor)
         .prev('span.prop').text(commentBackColor+" ("+Math.round(commentBackColor*100/255)+"%)")
@@ -569,7 +586,7 @@ function openOption(sw){
     ;
     $("#isCommentPadZero").prop("checked", isCommentPadZero);
     $("#isCommentTBorder").prop("checked", isCommentTBorder);
-    $('#itimePosition [type="radio"][name="timePosition"]').val([timePosition]);
+    $('#itimePosition input[type="radio"][name="timePosition"]').val([timePosition]);
     $('#itimePosition').css("display",isTimeVisible?"flex":"none");
     $("#notifySeconds").val(notifySeconds);
     $('#settcont>#windowresize>#movieheight input[type="radio"][name="movieheight"]').val([0]);
@@ -585,20 +602,23 @@ function openOption(sw){
     $("#isTabSoundplay").prop("checked",isTabSoundplay);
     $("#isOpenPanelwCome").prop("checked",isOpenPanelwCome);
     $("#isProtitleVisible").prop("checked",isProtitleVisible);
-    $('#iprotitlePosition [type="radio"][name="protitlePosition"]').val([protitlePosition]);
+    $('#iprotitlePosition input[type="radio"][name="protitlePosition"]').val([protitlePosition]);
     $('#iprotitlePosition').css("display",isProtitleVisible?"flex":"none");
-    $('#iproSamePosition [type="radio"][name="proSamePosition"]').val([proSamePosition]);
-    $('#iproSamePosition').css("display",(isProtitleVisible&&isTimeVisible)?"block":"none");
+    $('#iproSamePosition input[type="radio"][name="proSamePosition"]').val([proSamePosition]);
+    $('#iproSamePosition').css("display",(isProtitleVisible&&isTimeVisible)?"flex":"none");
+    $('#isCommentWide').prop("checked",isCommentWide);
+    $('#isProTextLarge').prop("checked",isProTextLarge);
+    setTimeout(optionStatsUpdate,500,false);
 }
 function closeOption(){
     $("#settcont").css("display","none")
         .css("right","40px")
     ;
-    $("#settcont .rightshift").css("display","none");
-    $("#settcont .leftshift").css("display","");
+    $(".rightshift").css("display","none");
+    $(".leftshift").css("display","");
     $(EXcomelist).children('div').css("background-color","")
         .css("color","")
-        .children('p[class^="styles__message___"]').css("color","")
+        .children('[class^="styles__message___"]').css("color","")
     ;
     setOptionElement();
 }
@@ -606,9 +626,9 @@ function optionHeightFix(){
     var settcontjq = $("#settcont");
     var settcontheight=settcontjq[0].scrollHeight;
     var settcontpadv=parseInt(settcontjq.css("padding-top"))+parseInt(settcontjq.css("padding-bottom"));
-    if(settcontheight>$(window).height()-105-settcontpadv){
+    if(settcontheight>window.innerHeight-105-settcontpadv){
 //console.log("optionHeightFix: "+settcontjq.height()+" -> "+($(window).height()-105-settcontpadv));
-        settcontjq.height($(window).height()-105-settcontpadv).css("overflow-y", "scroll");
+        settcontjq.height(window.innerHeight-105-settcontpadv).css("overflow-y", "scroll");
     }
 }
 function toast(message) {
@@ -631,15 +651,15 @@ console.log("delayset retry");
     }
     createSettingWindow();
     arrayFullNgMaker();
-    if($('body:first>#moveContainer').length==0){
+    if($('#moveContainer').length==0){
         var eMoveContainer=document.createElement('div');
         eMoveContainer.id="moveContainer";
 //        eMoveContainer.setAttribute("style","position:absolute;top:50px;left:1px;z-index:9;");
-        eMoveContainer.setAttribute("style","z-index:9;");
-        $("body").append(eMoveContainer);
+        eMoveContainer.setAttribute("style","z-index:9;"); //コメ欄10の下
+        document.body.appendChild(eMoveContainer);
     }
 //console.log("comevisiset delayset");
-    comevisiset(false);
+//    comevisiset(false);
 //    if(isSureReadComment){
 //console.log("popElement delayset");
 //        popElement();
@@ -654,26 +674,28 @@ console.log("delayset ok");
 }
 function optionStatsUpdate(outflg){
     var out=[0,0];
-    if($('body:first>#settcont').length==0){return;}
-    var tar=$('#settcont>#windowresize>#movieheight>#sourceheight');
+    if($('#settcont').length==0||$('#settcont').css("display")=="none"){return;}
+    var tar=$('#sourceheight');
     if(bginfo[0]>0&&tar.length>0){
         tar.text("(ソース:"+bginfo[0]+"p)")
-            .css("display","")
+            .css("display","block")
         ;
+    }else{
+        tar.css("display","none");
     }
-    tar=$('#settcont>#windowresize>#windowsizes');
-    if(EXwatchingnum&&tar.length>0){
+    tar=$('#windowsizes');
+    if(EXwatchingnum!==undefined&&tar.length>0){
         var jo=$(EXobli.children[EXwatchingnum]);
         var omw=jo.width();
         var omh=jo.height();
-        var oww=$(window).width();
-        var owh=$(window).height();
+        var oww=window.innerWidth;
+        var owh=window.innerHeight;
         var opw=oww-omw;
         var opb=Math.floor((owh-omh)/2);
         var opt=owh-omh-opb;
         var nmw=omw;
         var nmh=omh;
-        var sm=parseInt($('#settcont>#windowresize>#movieheight input[type="radio"][name="movieheight"]:checked').val());
+        var sm=parseInt($('#movieheight input[type="radio"][name="movieheight"]:checked').val());
         if(sm>0){
             nmh=sm;
             nmw=Math.ceil(nmh*16/9);
@@ -681,7 +703,7 @@ function optionStatsUpdate(outflg){
         var npw=opw;
         var npb=opb;
         var npt=opt;
-        var sw=parseInt($('#settcont>#windowresize>#windowheight input[type="radio"][name="windowheight"]:checked').val());
+        var sw=parseInt($('#windowheight input[type="radio"][name="windowheight"]:checked').val());
         switch(sw){
             case 0: //変更なし
                 npb=Math.floor((owh-nmh)/2);
@@ -733,23 +755,24 @@ console.log("createSettingWindow retry");
             }
         });
     }
-    if($('body:first>#settcont').length==0){
+    if($('#settcont').length==0){
         var settcont = document.createElement("div");
         settcont.id = "settcont";
         //設定ウィンドウの中身
         settcont.innerHTML = "<input type=button class=closeBtn value=閉じる style='position:absolute;top:10px;right:10px;'><br>"+generateOptionHTML(false) + "<br><input type=button id=saveBtn value=一時保存> <input type=button class=closeBtn value=閉じる><br>※ここでの設定はこのタブでのみ保持され、このタブを閉じると全て破棄されます。<hr><input type='button' id='clearLocalStorage' value='localStorageクリア'>";
-        settcont.style = "width:640px;position:absolute;right:40px;top:44px;background-color:white;opacity:0.8;padding:20px;display:none;z-index:12;";
+        settcont.style = "width:640px;position:absolute;right:40px;top:44px;background-color:white;opacity:0.8;padding:20px;display:none;z-index:12;";//コメ欄10より上の番組情報等11より上
         $(settcont).prependTo('body');
-        $('#settcont #CommentColorSettings').change(setComeColorChanged);
-        $('#settcont #itimePosition,#settcont #isTimeVisible').change(setTimePosiChanged);
-        $("#settcont .closeBtn").on("click", closeOption);
-        $("#settcont #clearLocalStorage").on("click", setClearStorageClicked);
-        $("#settcont #saveBtn").on("click",setSaveClicked);
-        $('#settcont #iprotitlePosition,#settcont #isProtitleVisible').change(setProtitlePosiChanged);
-        $('#settcont #iproSamePosition').change(setProSamePosiChanged);
+        $('#CommentColorSettings').change(setComeColorChanged);
+        $('#itimePosition,#isTimeVisible').change(setTimePosiChanged);
+        $(".closeBtn").on("click", closeOption);
+        $("#clearLocalStorage").on("click", setClearStorageClicked);
+        $("#saveBtn").on("click",setSaveClicked);
+        $('#iprotitlePosition,#isProtitleVisible').change(setProtitlePosiChanged);
+        $('#iproSamePosition').change(setProSamePosiChanged);
+        $('#isProTextLarge').change(setProTextSizeChanged);
     }
     $("#CommentMukouSettings").hide();
-    $("#settcont #CommentColorSettings").css("width","600px")
+    $("#CommentColorSettings").css("width","600px")
         .css("padding","8px")
         .css("border","1px solid black")
         .children('div').css("clear","both")
@@ -757,7 +780,7 @@ console.log("createSettingWindow retry");
         .next('span.prop').css("padding","0px 4px")
         .next('input[type="range"]').css("float","right")
     ;
-    $("#settcont #itimePosition").insertBefore("#settcont #isTimeVisible+*")
+    $("#itimePosition").insertBefore("#isTimeVisible+*")
         .css("border","1px solid black")
         .css("margin-left","16px")
         .css("display","flex")
@@ -768,7 +791,7 @@ console.log("createSettingWindow retry");
         .css("margin","1px 0px")
         .children().css("margin-left","4px")
     ;
-    $("#settcont #iprotitlePosition").insertBefore("#settcont #isProtitleVisible+*")
+    $("#iprotitlePosition").insertBefore("#isProtitleVisible+*")
         .css("border","black solid 1px")
         .css("margin-left","16px")
         .css("display","flex")
@@ -778,37 +801,39 @@ console.log("createSettingWindow retry");
         .css("margin","1px 0px")
         .children().css("margin-left","4px")
     ;
-    $("#settcont #iproSamePosition").insertBefore("#settcont #isProtitleVisible")
+    $("#iproSamePosition").insertBefore("#isProtitleVisible")
         .css("border","black solid 1px")
         .children().css("display","flex")
         .css("flex-direction","row")
         .css("margin","1px 0px")
         .children().css("margin-left","4px")
     ;
-    $('<span style="margin-left:4px;">↑と↓が同じ位置の場合: </span>').prependTo("#settcont #iproSamePosition>*");
-    if($('#settcont .leftshift').length==0){
-        $('<input type="button" class="leftshift" value="←この画面を少し左へ" style="float:right;margin-top:10px;padding:0px 3px;">').appendTo('#settcont #CommentColorSettings');
-        $("#settcont .leftshift").on("click",function(){
+    if($('#prosamedesc').length==0){
+        $('<span id="prosamedesc" style="margin-left:4px;">↑と↓が同じ位置の場合: </span>').prependTo("#iproSamePosition>*");
+    }
+    if($('.leftshift').length==0){
+        $('<input type="button" class="leftshift" value="←この画面を少し左へ" style="float:right;margin-top:10px;padding:0px 3px;">').appendTo('#CommentColorSettings');
+        $(".leftshift").on("click",function(){
             $("#settcont").css("right","320px");
-            $("#settcont .leftshift").css("display","none");
-            $("#settcont .rightshift").css("display","");
+            $(".leftshift").css("display","none");
+            $(".rightshift").css("display","");
         });
     }
-    if($('#settcont .rightshift').length==0){
-        $('<input type="button" class="rightshift" value="この画面を右へ→" style="float:right;margin-top:10px;display:none;padding:0px 3px;">').appendTo('#settcont #CommentColorSettings');
-        $("#settcont .rightshift").on("click",function(){
+    if($('.rightshift').length==0){
+        $('<input type="button" class="rightshift" value="この画面を右へ→" style="float:right;margin-top:10px;display:none;padding:0px 3px;">').appendTo('#CommentColorSettings');
+        $(".rightshift").on("click",function(){
             $("#settcont").css("right","40px");
-            $("#settcont .rightshift").css("display","none");
-            $("#settcont .leftshift").css("display","");
+            $(".rightshift").css("display","none");
+            $(".leftshift").css("display","");
             $('#PsaveCome').prop("disabled",true)
                 .css("color","gray")
             ;
             setTimeout(clearBtnColored,1200,$('#PsaveCome'));
         });
     }
-    if($('#settcont #windowresize').length==0){
-        $('<div id="windowresize">ウィンドウのサイズ変更<span id="windowsizes"></span></div>').insertAfter('#settcont #CommentColorSettings');
-        $('#settcont>#windowresize').css("display","flex")
+    if($('#windowresize').length==0){
+        $('<div id="windowresize">ウィンドウのサイズ変更<span id="windowsizes"></span></div>').insertAfter('#CommentColorSettings');
+        $('#windowresize').css("display","flex")
             .css("flex-direction","column")
             .css("margin-top","8px")
             .css("padding","8px")
@@ -816,16 +841,16 @@ console.log("createSettingWindow retry");
             .children('#windowsizes').css("display","none")
         ;
     }
-    if($('#settcont #movieheight').length==0){
-        $('<div id="movieheight">映像の縦長さ<br><p id="sourceheight"></p></div>').appendTo('#settcont #windowresize');
-        $('<div><input type="radio" name="movieheight" value=0>変更なし</div>').appendTo('#settcont #movieheight');
-        $('<div><input type="radio" name="movieheight" value=240>240px</div>').appendTo('#settcont #movieheight');
-        $('<div><input type="radio" name="movieheight" value=360>360px</div>').appendTo('#settcont #movieheight');
-        $('<div><input type="radio" name="movieheight" value=480>480px</div>').appendTo('#settcont #movieheight');
-        $('<div><input type="radio" name="movieheight" value=720>720px</div>').appendTo('#settcont #movieheight');
-        $('<div><input type="radio" name="movieheight" value=1080>1080px</div>').appendTo('#settcont #movieheight');
-        $('#settcont #movieheight input[type="radio"][name="movieheight"]').val([0]);
-        $('#settcont #movieheight').css("display","flex")
+    if($('#movieheight').length==0){
+        $('<div id="movieheight">映像の縦長さ<br><p id="sourceheight"></p></div>').appendTo('#windowresize');
+        $('<div><input type="radio" name="movieheight" value=0>変更なし</div>').appendTo('#movieheight');
+        $('<div><input type="radio" name="movieheight" value=240>240px</div>').appendTo('#movieheight');
+        $('<div><input type="radio" name="movieheight" value=360>360px</div>').appendTo('#movieheight');
+        $('<div><input type="radio" name="movieheight" value=480>480px</div>').appendTo('#movieheight');
+        $('<div><input type="radio" name="movieheight" value=720>720px</div>').appendTo('#movieheight');
+        $('<div><input type="radio" name="movieheight" value=1080>1080px</div>').appendTo('#movieheight');
+        $('#movieheight input[type="radio"][name="movieheight"]').val([0]);
+        $('#movieheight').css("display","flex")
             .css("flex-direction","row")
             .css("flex-wrap","wrap")
             .css("padding","0px 8px")
@@ -834,14 +859,14 @@ console.log("createSettingWindow retry");
             .change(setSaveDisable)
         ;
     }
-    if($('#settcont #windowheight').length==0){
-        $('<div id="windowheight">ウィンドウの縦長さ</div>').appendTo('#settcont #windowresize');
-        $('<div><input type="radio" name="windowheight" value=0>変更なし</div>').appendTo('#settcont #windowheight');
-        $('<div><input type="radio" name="windowheight" value=1>映像の縦長さに合わせる</div>').appendTo('#settcont #windowheight');
-        $('<div><input type="radio" name="windowheight" value=2>黒枠の分だけ空ける</div>').appendTo('#settcont #windowheight');
-        $('<div><input type="radio" name="windowheight" value=3>現在の余白を維持</div>').appendTo('#settcont #windowheight');
-        $('#settcont #windowheight input[type="radio"][name="windowheight"]').val([0]);
-        $('#settcont #windowheight').css("display","flex")
+    if($('#windowheight').length==0){
+        $('<div id="windowheight">ウィンドウの縦長さ</div>').appendTo('#windowresize');
+        $('<div><input type="radio" name="windowheight" value=0>変更なし</div>').appendTo('#windowheight');
+        $('<div><input type="radio" name="windowheight" value=1>映像の縦長さに合わせる</div>').appendTo('#windowheight');
+        $('<div><input type="radio" name="windowheight" value=2>黒枠の分だけ空ける</div>').appendTo('#windowheight');
+        $('<div><input type="radio" name="windowheight" value=3>現在の余白を維持</div>').appendTo('#windowheight');
+        $('#windowheight input[type="radio"][name="windowheight"]').val([0]);
+        $('#windowheight').css("display","flex")
             .css("flex-direction","row")
             .css("flex-wrap","wrap")
             .css("padding","0px 8px")
@@ -849,125 +874,150 @@ console.log("createSettingWindow retry");
             .change(setSaveDisable)
         ;
     }
-    if($('#settcont #PsaveCome').length==0){
-        $('<input type="button" id="PsaveCome" class="Psave" value="このコメント外見設定を永久保存(上書き)">').appendTo('#settcont #CommentColorSettings');
-        $('#settcont #PsaveCome').css("margin","8px 0 0 24px")
+    if($('#PsaveCome').length==0){
+        $('<input type="button" id="PsaveCome" class="Psave" value="このコメント外見設定を永久保存(上書き)">').appendTo('#CommentColorSettings');
+        $('#PsaveCome').css("margin","8px 0 0 24px")
             .on("click",setPSaveCome)
         ;
     }
-    if($('#settcont #PsaveNG').length==0){
-        $('<input type="button" id="PsaveNG" class="Psave" value="←これらを永久保存(上書き)">').insertAfter('#settcont #fullNg');
-        $('#settcont #PsaveNG').css("margin","8px 0 0 8px")
+    if($('#PsaveNG').length==0){
+        $('<input type="button" id="PsaveNG" class="Psave" value="←これらを永久保存(上書き)">').insertAfter('#fullNg');
+        $('#PsaveNG').css("margin","8px 0 0 8px")
             .on("click",setPSaveNG)
         ;
-        $('<div style="clear:both;">').insertAfter('#settcont #PsaveNG');
-        $('#settcont #fullNg').css("float","left");
+        $('<div style="clear:both;">').insertAfter('#PsaveNG');
+        $('#fullNg').css("float","left");
     }
-    $('#settcont .Psave').css("margin-left","8px")
+    $('.Psave').css("margin-left","8px")
         .css("padding","0px 3px")
     ;
-    if($('#settcont #CommentMukouSettings .setTables').length==0){
-        $('#settcont #CommentMukouSettings').wrapInner('<div id="ComeMukouD">');
-        $('<div id="ComeMukouO" class="setTables">コメント数が表示されないとき</div>').prependTo('#settcont #CommentMukouSettings');
-        $('#settcont #ComeMukouO').css("margin-top","8px")
+    if($('#ComeMukouO').length==0){
+        $('#CommentMukouSettings').wrapInner('<div id="ComeMukouD">');
+        $('<div id="ComeMukouO" class="setTables">コメント数が表示されないとき</div>').prependTo('#CommentMukouSettings');
+        $('#ComeMukouO').css("margin-top","8px")
             .css("padding","8px")
             .css("border","1px solid black")
         ;
-        $('<table id="setTable">').appendTo('#settcont #ComeMukouO');
-        $('#settcont table#setTable').css("border-collapse","collapse");
-        $('<tr><th></th><th colspan=2>画面真っ黒</th><th>画面縮小</th><th colspan=2>音量ミュート</th></tr>').appendTo('#settcont table#setTable');
-        $('<tr><td>適用</td><td></td><td></td><td></td><td></td><td></td></tr>').appendTo('#settcont table#setTable');
-        $('<tr><td>画面クリックで<br>解除・再適用</td><td colspan=2></td><td></td><td colspan=2></td></tr>').appendTo('#settcont table#setTable');
+        $('<table id="setTable">').appendTo('#ComeMukouO');
+        var stjo=$('#setTable');
+        var sttr=stjo.contents().find('tr');
+        stjo.css("border-collapse","collapse");
+        $('<tr><th></th><th colspan=2>画面真っ黒</th><th>画面縮小</th><th colspan=2>音量ミュート</th></tr>').appendTo(stjo);
+        $('<tr><td>適用</td><td></td><td></td><td></td><td></td><td></td></tr>').appendTo(stjo);
+        $('<tr><td>画面クリックで<br>解除・再適用</td><td colspan=2></td><td></td><td colspan=2></td></tr>').appendTo(stjo);
 
-        $('#settcont #isCMBlack').appendTo('#settcont table#setTable tr:eq(1)>td:eq(1)');
-        $('#settcont #isCMBkTrans').appendTo('#settcont table#setTable tr:eq(1)>td:eq(1)').css("display","none");
-        $('<input type="radio" name="cmbktype" value=0>').appendTo('#settcont table#setTable tr:eq(1)>td:eq(2)')
+        sttr=stjo.contents().find('tr');
+        var stra=sttr.eq(1).children('td');
+        var strb=sttr.eq(2).children('td');
+        $('#isCMBlack').appendTo(stra.eq(1));
+        $('#isCMBkTrans').appendTo(stra.eq(1)).css("display","none");
+        $('<input type="radio" name="cmbktype" value=0>').appendTo(stra.eq(2))
             .after("全面真黒<br>")
         ;
-        $('<input type="radio" name="cmbktype" value=1>').appendTo('#settcont table#setTable tr:eq(1)>td:eq(2)')
+        $('<input type="radio" name="cmbktype" value=1>').appendTo(stra.eq(2))
             .after("下半透明")
         ;
-        $('#settcont input[type="radio"][name="cmbktype"]').prop("disabled",!isCMBlack)
+        stra.eq(2).children('input[type="radio"][name="cmbktype"]').prop("disabled",!isCMBlack)
             .val([isCMBkTrans?1:0])
+            .change(setCMBKChangedR)
         ;
-        $('#settcont table#setTable input[type="radio"][name="cmbktype"]').change(setCMBKChangedR);
 
-        $('#settcont #CMsmall').appendTo('#settcont table#setTable tr:eq(1)>td:eq(3)').after("％")
+        $('#CMsmall').appendTo(stra.eq(3)).after("％")
             .css("text-align","right")
             .css("width","4em")
         ;
 
-        $('#settcont #isCMsoundoff').appendTo('#settcont table#setTable tr:eq(1)>td:eq(4)');
-        $('#settcont #isTabSoundplay').appendTo('#settcont table#setTable tr:eq(1)>td:eq(4)').css("display","none");
-        $('<input type="radio" name="cmsotype" value=0>').appendTo('#settcont table#setTable tr:eq(1)>td:eq(5)')
+        $('#isCMsoundoff').appendTo(stra.eq(4));
+        $('#isTabSoundplay').appendTo(stra.eq(4)).css("display","none");
+        $('<input type="radio" name="cmsotype" value=0>').appendTo(stra.eq(5))
             .after("プレイヤー<br>")
         ;
-        $('<input type="radio" name="cmsotype" value=1>').appendTo('#settcont table#setTable tr:eq(1)>td:eq(5)')
+        $('<input type="radio" name="cmsotype" value=1>').appendTo(stra.eq(5))
             .after("タブ設定")
         ;
-        $('#settcont input[type="radio"][name="cmsotype"]').prop("disabled",!isCMsoundoff)
+        stra.eq(5).children('input[type="radio"][name="cmsotype"]').prop("disabled",!isCMsoundoff)
             .val([isTabSoundplay?1:0])
+            .change(setCMsoundChangedR)
         ;
-        $('#settcont table#setTable input[type="radio"][name="cmsotype"]').change(setCMsoundChangedR);
 
-        $('#settcont table#setTable #isCMBlack').change(setCMBKChangedB);
-        $('#settcont table#setTable #CMsmall').change(setCMzoomChangedR);
-        $('#settcont table#setTable #isCMsoundoff').change(setCMsoundChangedB);
-//        $('#settcont table#setTable tr:eq(2)>td:eq(0)').html('画面クリックで<br>解除・再適用');
-        $('#settcont #isCMBkR').appendTo('#settcont table#setTable tr:eq(2)>td:eq(1)');
-        $('#settcont #isCMsmlR').appendTo('#settcont table#setTable tr:eq(2)>td:eq(2)');
-        $('#settcont #isCMsoundR').appendTo('#settcont table#setTable tr:eq(2)>td:eq(3)');
-        $('#settcont table#setTable td').css("border","1px solid black")
+        $('#isCMBlack').change(setCMBKChangedB);
+        $('#CMsmall').change(setCMzoomChangedR);
+        $('#isCMsoundoff').change(setCMsoundChangedB);
+        $('#isCMBkR').appendTo(strb.eq(1));
+        $('#isCMsmlR').appendTo(strb.eq(2));
+        $('#isCMsoundR').appendTo(strb.eq(3));
+        stra.add(strb).css("border","1px solid black")
             .css("text-align","center")
             .css("padding","3px")
         ;
-        $('#settcont table#setTable tr:eq(1)>td:eq(1)').css("border-right","none");
-        $('#settcont table#setTable tr:eq(1)>td:eq(2)').css("border-left","none")
-            .css("text-align","left")
-        ;
-        $('#settcont table#setTable tr:eq(1)>td:eq(4)').css("border-right","none");
-        $('#settcont table#setTable tr:eq(1)>td:eq(5)').css("border-left","none")
+        stra.eq(1).add(stra.eq(4)).css("border-right","none");
+        stra.eq(2).add(stra.eq(5)).css("border-left","none")
             .css("text-align","left")
         ;
 
-        $('<div id="ComeMukouW" class="setTables">↑の実行待機(秒)</div>').insertAfter('#settcont #ComeMukouO');
-        $('#settcont #ComeMukouW').css("margin-top","8px")
+        $('<div id="ComeMukouW" class="setTables">↑の実行待機(秒)</div>').insertAfter('#ComeMukouO');
+        $('#ComeMukouW').css("margin-top","8px")
             .css("padding","8px")
             .css("border","1px solid black")
         ;
-        $('#settcont #beforeCMWait').appendTo('#settcont #ComeMukouW')
+        $('#beforeCMWait').appendTo('#ComeMukouW')
             .before("　開始後")
         ;
-        $('#settcont #afterCMWait').appendTo('#settcont #ComeMukouW')
+        $('#afterCMWait').appendTo('#ComeMukouW')
             .before("　終了後")
             .after("<br>待機時間中、押している間は実行せず、離すと即実行するキー<br>")
         ;
-        $('#settcont #isManualKeyCtrlL').appendTo('#settcont #ComeMukouW').after("左ctrl");
-        $('#settcont #isManualKeyCtrlR').appendTo('#settcont #ComeMukouW').after("右ctrl");
-        $('#settcont #isManualMouseBR').appendTo('#settcont #ComeMukouW')
-            .before("<br>待機時間中、カーソルを合わせている間は実行せず、外すと即実行する場所<br>")
+        $('#isManualKeyCtrlL').appendTo('#ComeMukouW').after("左ctrl");
+        $('#isManualKeyCtrlR').appendTo('#ComeMukouW').after("右ctrl");
+        $('#isManualMouseBR').appendTo('#ComeMukouW')
+            .before("<br>待機時間中、カーソルを1秒以上連続で合わせている間は実行せず、外すと即実行する場所<br>")
             .after("右下のコメント数表示部")
         ;
-        $('#settcont #ComeMukouD').remove();
+        $('#ComeMukouD').remove();
+    }
+    if($('#epnumedit').length==0){
+        $('<div id="epnumedit" style="border:1px solid black;padding:8px;margin-left:16px;display:flex;flex-direction:row;"><div>背景区切り数<input type="number" name="epcount" min=1 max=26></div><div style="margin-left:16px;">1番目の数字<input type="number" name="epfirst" min=1 max=26>(区切り数7以上の場合のみ表示)</div></div>').insertBefore("#isTimeVisible+*");
+        var epnume=$('#epnumedit').contents().find('input[type="number"]');
+        epnume.filter('[name="epcount"]').val(2)
+            .change(epcountchange)
+        ;
+        epnume.filter('[name="epfirst"]').val(1)
+            .change(epfirstchange)
+        ;
     }
 console.log("createSettingWindow ok");
+}
+function epcountchange(){
+    var c=parseInt($('#epnumedit input[type="number"][name="epcount"]').val());
+    var f=parseInt($('#epnumedit input[type="number"][name="epfirst"]').val());
+    var eo='<div style="border-left:1px solid rgba(255,255,255,0.2);flex:1 0 1px;">';
+    var ea='';
+    for(var i=0;i<c;i++){
+        ea+=eo+(c>6?(i+f):'&nbsp;')+'</div>';
+    }
+    $('#proTimeEpNum').html(ea);
+}
+function epfirstchange(){
+    if(parseInt($('#epnumedit input[type="number"][name="epcount"]').val())>6){
+        epcountchange();
+    }
 }
 function setClearStorageClicked(){
     window.localStorage.clear();
 console.info("cleared localStorage");
 }
 function moveComeTopFilter(){
-    var jo=$('body:first>#moveContainer>span.movingComment');
+    var jo=$('.movingComment');
     var i=jo.length-1
     while(i>=0){
-        if(jo.eq(i).position().top>$(window).height()-48-61){
+        if(jo.eq(i).position().top>window.innerHeight-48-61){
             jo.eq(i).remove();
         }
         i-=1;
     }
 }
 function setSaveDisable(){
-    $("#settcont #saveBtn").prop("disabled",true)
+    $("#saveBtn").prop("disabled",true)
         .css("color","gray")
     ;
 }
@@ -1043,7 +1093,7 @@ function setSaveClicked(){
     commentTextTrans = parseInt($("#commentTextTrans").val());
     isCommentPadZero = $("#isCommentPadZero").prop("checked");
     isCommentTBorder = $("#isCommentTBorder").prop("checked");
-    timePosition = $('#itimePosition [name="timePosition"]:checked').val();
+    timePosition = $('#itimePosition input[type="radio"][name="timePosition"]:checked').val();
     notifySeconds = parseInt($("#notifySeconds").val());
     cmblockia = Math.max(1,1+parseInt($("#beforeCMWait").val()));
     cmblockib = -Math.max(1,1+parseInt($("#afterCMWait").val()));
@@ -1056,24 +1106,36 @@ function setSaveClicked(){
     isTabSoundplay = $("#isTabSoundplay").prop("checked");
     isOpenPanelwCome=$("#isOpenPanelwCome").prop("checked");
     isProtitleVisible=$("#isProtitleVisible").prop("checked");
-    protitlePosition=$('#iprotitlePosition [name="protitlePosition"]:checked').val();
-    proSamePosition=$('#iproSamePosition [name="proSamePosition"]:checked').val();
+    protitlePosition=$('#iprotitlePosition input[type="radio"][name="protitlePosition"]:checked').val();
+    proSamePosition=$('#iproSamePosition input[type="radio"][name="proSamePosition"]:checked').val();
+    isCommentWide=$('#isCommentWide').prop("checked");
+    isProTextLarge=$('#isProTextLarge').prop("checked");
 
     setOptionHead();
     setOptionElement();
     arrayFullNgMaker();
+    if(settings.isAlwaysShowPanel){
+        popElement({head:true,foot:true,side:true});
+        forElementClose=0;
+    }else if(isOpenPanelwCome&&isComeOpen()){
+        popElement({head:true,foot:true,side:true});
+        forElementClose=5;
+    }else if(!isOpenPanelwCome&&isComeOpen()){
+        hideElement({head:true,foot:true,side:true});
+        forElementClose=0;
+    }
 //console.log("comevisiset savebtnclick");
-    setTimeout(comevisiset,200,false);
+//    setTimeout(comevisiset,200,false);
     optionHeightFix();
-    var sm=parseInt($('#settcont>#windowresize>#movieheight input[type="radio"][name="movieheight"]:checked').val());
-    var sw=parseInt($('#settcont>#windowresize>#windowheight input[type="radio"][name="windowheight"]:checked').val());
+    var sm=parseInt($('#movieheight input[type="radio"][name="movieheight"]:checked').val());
+    var sw=parseInt($('#windowheight input[type="radio"][name="windowheight"]:checked').val());
 //console.log("sm="+sm+",sw="+sw);
     if(sm!=0||sw!=0){
         var s=optionStatsUpdate(true);
         if(s[0]!=0||s[1]!=0){
             chrome.runtime.sendMessage({type:"windowresize",valw:s[0],valh:s[1]},function(r){
                 setTimeout(optionHeightFix,1000);
-                setTimeout(comevisiset,1000,false);
+//                setTimeout(comevisiset,1000,false);
                 setTimeout(moveComeTopFilter,1000);
             });
         }
@@ -1084,54 +1146,93 @@ function setSaveClicked(){
     ;
     setTimeout(clearBtnColored,1200,$("#saveBtn"));
 }
-function setProSamePosiChanged(){
-    if($("#isProtitleVisible").prop("checked")||$("#isTimeVisible").prop("checked")){
+function setProTextSizeChanged(){
+    setProSamePosiChanged(false,$('#isProTextLarge').prop("checked"));
+}
+function setProSamePosiChanged(pophide,bigtext){
+//ref:
+//setTimePosiChanged
+//setProtitlePosiChanged
+//setoptionelement
+//hideElement,popElement pophide=true 開閉遅延を考慮する
+    var titleprop="";
+    var timeprop="";
+    var sameprop="";
+    if($("#settcont").css("display")=="block"){
         if($("#isProtitleVisible").prop("checked")){
-            createProtitle(0,false);
+            titleprop=$('#iprotitlePosition input[type="radio"][name="protitlePosition"]:checked').val();
         }
         if($("#isTimeVisible").prop("checked")){
-            createTime(0,false);
+            timeprop=$('#itimePosition input[type="radio"][name="timePosition"]:checked').val();
         }
-        setProtitlePosition($('#itimePosition [name="timePosition"]:checked').val(),$('#iprotitlePosition [name="protitlePosition"]:checked').val());
+        sameprop=$('#iproSamePosition input[type="radio"][name="proSamePosition"]:checked').val();
+        if(bigtext===undefined){
+            bigtext=$("#isProTextLarge").prop("checked");
+        }
+    }else{
+        if(isProtitleVisible){
+            titleprop=protitlePosition;
+        }
+        if(isTimeVisible){
+            timeprop=timePosition;
+        }
+        sameprop=proSamePosition;
+        if(bigtext===undefined){
+            bigtext=isProTextLarge;
+        }
     }
+    if(titleprop!=""){
+        createProtitle(0,bigtext);
+    }else{
+        createProtitle(1);
+    }
+    if(timeprop!=""){
+        createTime(0,bigtext);
+    }else{
+        createTime(1);
+    }
+//console.log("setProSamePosiChanged:time="+timeprop+",title="+titleprop+",same="+sameprop);
+    proPositionAllReset(bigtext);
+    setTimePosition(timeprop,titleprop,sameprop,bigtext);
+    setProtitlePosition(timeprop,titleprop,sameprop,bigtext);
+    proSamePositionFix(timeprop,titleprop,sameprop,bigtext);
+    setTimeout(comemarginfix,(pophide?110:0),(pophide?1:0),timeprop,titleprop,sameprop,bigtext);
 }
 function setProtitlePosiChanged(){
+    //選択肢の表示切替だけして本体はsetProSamePosiChangedで行う
     if($("#isProtitleVisible").prop("checked")){
         $('#iprotitlePosition').css("display","flex");
-        createProtitle(0,false);
-        setProtitlePosition($('#itimePosition [name="timePosition"]:checked').val(),$('#iprotitlePosition [name="protitlePosition"]:checked').val());
     }else{
         $('#iprotitlePosition').css("display","none");
-        createProtitle(1);
-        setProtitlePosition();
-        $('#tProtitle').css("display","none");
     }
+    //sameposi表示切替
     if($("#isProtitleVisible").prop("checked")&&$("#isTimeVisible").prop("checked")){
         $('#iproSamePosition').css("display","block");
     }else{
         $('#iproSamePosition').css("display","none");
     }
+    setProSamePosiChanged();
 }
 function setTimePosiChanged(){
+    //選択肢の表示切替だけして本体はsetProSamePosiChangedで行う
     if($("#isTimeVisible").prop("checked")){
         $('#itimePosition').css("display","flex");
-        createTime(0,false);
-        setTimePosition($('#itimePosition [name="timePosition"]:checked').val(),$('#iprotitlePosition [name="protitlePosition"]:checked').val());
+        $('#epnumedit').css("display","flex");
     }else{
         $('#itimePosition').css("display","none");
-        createTime(1);
-        setTimePosition();
-        $('#forProEndTxt,#forProEndBk').css("display","none");
+        $('#epnumedit').css("display","none");
     }
+    //sameposi表示切替
     if($("#isProtitleVisible").prop("checked")&&$("#isTimeVisible").prop("checked")){
         $('#iproSamePosition').css("display","block");
     }else{
         $('#iproSamePosition').css("display","none");
     }
+    setProSamePosiChanged();
 }
 function setCMzoomChangedR(){
-    var jo=$('#settcont #isCMsmlR');
-    if(parseInt($("#settcont #CMsmall").val())==100){
+    var jo=$('#isCMsmlR');
+    if(parseInt($("#CMsmall").val())==100){
         jo.prop("checked",false)
             .prop("disabled",true)
         ;
@@ -1140,39 +1241,62 @@ function setCMzoomChangedR(){
     }
 }
 function setCMsoundChangedB(){
-    $('#settcont input[type="radio"][name="cmsotype"]').prop("disabled",!$("#settcont #isCMsoundoff").prop("checked"));
-    $('#settcont #isCMsoundR').prop("checked",false)
-        .prop("disabled",!$("#settcont #isCMsoundoff").prop("checked"))
+    var b=$("#isCMsoundoff").prop("checked");
+    $('#CommentMukouSettings input[type="radio"][name="cmsotype"]').prop("disabled",!b);
+    $('#isCMsoundR').prop("checked",false)
+        .prop("disabled",!b)
     ;
 }
 function setCMBKChangedB(){
-    $('#settcont input[type="radio"][name="cmbktype"]').prop("disabled",!$("#settcont #isCMBlack").prop("checked"));
-    $('#settcont #isCMBkR').prop("checked",false)
-        .prop("disabled",!$("#settcont #isCMBlack").prop("checked"))
+    var b=$("#isCMBlack").prop("checked")
+    $('#CommentMukouSettings input[type="radio"][name="cmbktype"]').prop("disabled",!b);
+    $('#isCMBkR').prop("checked",false)
+        .prop("disabled",!b)
     ;
 }
 function setCMBKChangedR(){
-    $('#settcont #isCMBkTrans').prop("checked",$('#settcont input[type="radio"][name="cmbktype"]:checked').val()==1?true:false);
+    $('#isCMBkTrans').prop("checked",$('#CommentMukouSettings input[type="radio"][name="cmbktype"]:checked').val()==1?true:false);
 }
 function setCMsoundChangedR(){
-    $('#settcont #isTabSoundplay').prop("checked",$('#settcont input[type="radio"][name="cmsotype"]:checked').val()==1?true:false);
+    $('#isTabSoundplay').prop("checked",$('#CommentMukouSettings input[type="radio"][name="cmsotype"]:checked').val()==1?true:false);
 }
 function setComeColorChanged(){
+//console.log("setComeColorChanged");
     var p=[];
-    $('#settcont #CommentColorSettings>div>input[type="range"]').each(function(i,jo){
-        $(jo).prev('span.prop').text($(jo).val()+" ("+Math.round($(jo).val()*100/255)+"%)");
-        p[i]=$(jo).val();
-    });
+    var jo=$('#CommentColorSettings input[type="range"]');
+    for(var i=0;i<jo.length;i++){
+        var jq=jo.eq(i);
+        var jv=jq.val();
+        jq.prevAll('span.prop').text(jv+" ("+Math.round(jv*100/255)+"%)");
+        p[i]=jv;
+    }
     var bc="rgba("+p[0]+","+p[0]+","+p[0]+","+(p[1]/255)+")";
     var tc="rgba("+p[2]+","+p[2]+","+p[2]+","+(p[3]/255)+")";
-    $(EXcomelist).children('div').css("background-color",bc)
+    $(EXcomelist).children().slice(0,10).css("background-color",bc)
         .css("color",tc)
-        .children('p[class^="styles__message___"]').css("color",tc)
+        .children('[class^="styles__message___"]').css("color",tc)
     ;
 }
 function toggleCommentList(){
 //console.log("comevisiset toggleCommentList");
-    comevisiset(true);
+//    comevisiset(true);
+    var jo=$(EXcomelist).parent();
+    var jv=jo.css("display");
+    if(jv!="none"){
+        jo.css("display","none");
+        $(EXcome).css("height","unset");
+        if(isInpWinBottom){
+            $(EXcome).css("top","unset")
+                .css("bottom","0px")
+            ;
+        }
+    }else{
+        jo.css("display",isInpWinBottom?"flex":"");
+        $(EXcome).css("height","")
+            .css("top","")
+            .css("bottom","")
+        ;
+    }
 }
 //function unpopHeader(){
 //console.log("unpopHeader");
@@ -1185,163 +1309,496 @@ function toggleCommentList(){
 //console.log("comevisiset unpopHeader");
 //    comevisiset(false);
 //}
-function popHeader(){
+//function popHeader(){
 //console.log("popHeader");
-    $(EXhead).css("visibility","visible")
-      .css("opacity",1)
-    ;
-    $(EXfoot).css("visibility","visible")
-      .css("opacity",1)
-    ;
+//    $(EXhead).css("visibility","visible")
+//      .css("opacity",1)
+//    ;
+//    $(EXfoot).css("visibility","visible")
+//      .css("opacity",1)
+//    ;
 //console.log("comevisiset popHeader");
-    comevisiset(false);
-}
-function comevisiset(sw){
+//    comevisiset(false);
+//}
+//function comevisiset(sw){
+//    setProSamePosiChanged();
+//}
+//function comevisiset(sw){
 //console.log("comevisiset");
-    var comeList = $(commentListParentSelector);
-    if(sw){
-        comeList.css("display",(comeList.css("display")!="none")?"none":(isInpWinBottom?"flex":"block"));
+//    var comeList = $(commentListParentSelector);
+//    if(sw){
+//        comeList.css("display",(comeList.css("display")!="none")?"none":(isInpWinBottom?"flex":"block"));
+//    }
+//    var contCome = $(EXcome);
+//    var comeForm = $(EXcomesend);
+//    var comeshown = $(EXcome).filter('[class*="TVContainer__right-slide--shown___"]').length>0?true:false;
+//    var hideCommentParam = isCustomPostWin?64:108;
+//    var clipSlideBarTop = ($(EXhead).css("visibility")=="visible")?44:0;
+//    var clipSlideBarBot = ($(EXfoot).css("visibility")=="visible")?61:0;
+//    var butscr = $(EXfoot).contents().find('button[class^="styles__full-screen___"]').first();
+//    var butvol = $(EXvolume);
+//    var itimeposi=($('#settcont').css("display")=="none")?(isTimeVisible?timePosition:""):($('#isTimeVisible').prop("checked")?$('#itimePosition input[type="radio"][name="timePosition"]:checked').val():"");
+//    var ititleposi=($('#settcont').css("display")=="none")?(isProtitleVisible?protitlePosition:""):($('#isProtitleVisible').prop("checked")?$('#iprotitlePosition input[type="radio"][name="protitlePosition"]:checked').val():"");
+//    var iprosame=($('#settcont').css("display")=="none")?proSamePosition:$('#iproSamePosition input[type="radio"][name="proSamePosition"]:checked').val();
+//    var timepadtop=(isTimeVisible&&(itimeposi=="windowtop")&&($(EXhead).css("visibility")=="hidden"))?15:0;
+//    var timepadbot=(isTimeVisible&&(itimeposi=="windowbottom")&&($(EXfoot).css("visibility")=="hidden"))?15:0;
+//    var titlepadtop=(isProtitleVisible&&(ititleposi=="windowtopright")&&($(EXhead).css("visibility")=="hidden"))?15:0;
+//    var titlepadbot=(isProtitleVisible&&(ititleposi=="windowbottomright")&&($(EXfoot).css("visibility")=="hidden"))?15:0;
+//    if(timepadtop==0||titlepadtop==0||iprosame=="vertical"){
+//        timepadtop+=titlepadtop;
+//        timepadbot+=titlepadbot;
+//    }
+//    contCome.css("transform",isSureReadComment?"translateX(0px)":"");
+//    if(isInpWinBottom){
+//        var b=80+((isSureReadComment||comeshown)?hideCommentParam:0);
+//        butscr.css("bottom",b+"px");
+//        butvol.css("bottom",b+"px");
+//        if(comeList.css("display")=="none"){
+//            contCome.css("position","absolute");
+//            contCome.css("top",(window.innerHeight-hideCommentParam-clipSlideBarBot)+"px");
+//            contCome.css("height",hideCommentParam+"px");
+//            comeForm.css("position","absolute");
+//            comeForm.css("top","");
+//            comeForm.css("bottom",0);
+//            comeForm.css("height",hideCommentParam+"px");
+//            comeList.css("position","absolute");
+//            comeList.css("width","100%");
+//        }else{
+//            contCome.css("position","absolute");
+//            contCome.css("top",(clipSlideBarTop+timepadtop)+"px");
+//            contCome.css("height",(window.innerHeight-clipSlideBarTop-clipSlideBarBot-timepadtop)+"px");
+//            comeForm.css("position","absolute");
+//            comeForm.css("top","");
+//            comeForm.css("bottom",0);
+//            comeForm.css("height",hideCommentParam+"px");
+//            comeList.css("position","absolute");
+//            comeList.css("bottom","");
+//            comeList.css("top",0);
+//            comeList.css("height",(window.innerHeight-hideCommentParam-clipSlideBarTop-clipSlideBarBot-timepadtop)+"px");
+//            comeList.css("width","100%");
+//        }
+//    }else{
+//        butscr.css("bottom","");
+//        butvol.css("bottom","");
+//        if(comeList.css("display")=="none"){
+//            contCome.css("position","absolute");
+//            contCome.css("top",clipSlideBarTop+"px");
+//            contCome.css("height",hideCommentParam+"px");
+//            comeForm.css("position","absolute");
+//            comeForm.css("bottom","");
+//            comeForm.css("top",0);
+//            comeForm.css("height",hideCommentParam+"px");
+//            comeList.css("position","absolute");
+//            comeList.css("width","100%");
+//        }else{
+//            contCome.css("position","absolute");
+//            contCome.css("top",clipSlideBarTop+"px");
+//            contCome.css("height",(window.innerHeight-clipSlideBarTop-clipSlideBarBot-timepadbot)+"px");
+//            comeForm.css("position","absolute");
+//            comeForm.css("bottom","");
+//            comeForm.css("top",0);
+//            comeForm.css("height",hideCommentParam+"px");
+//            comeList.css("position","absolute");
+//            comeList.css("top","");
+//            comeList.css("bottom",0);
+//            comeList.css("height",(window.innerHeight-hideCommentParam-clipSlideBarTop-clipSlideBarBot-timepadbot)+"px");
+//            comeList.css("width","100%");
+//        }
+//    }
+//    setProSamePosiChanged();
+//}
+function hideElement(inp){
+//trueなら積極的に隠すよう設定
+//falseはtrueの解除(trueの設定値どおりの時のみ機能するので、積極的に表示する場合はpopElementを使用する)
+//true,falseは見た目の変化のみで内部の開閉状態は変化しないので映像の横縮小などは変化しない
+//"force"ならoverlayをクリックさせて閉じる（視聴中番組情報、放送中番組一覧、コメント一覧）
+//クリックによる影響（他要素の開閉やイベント）は全く考慮していない
+//ref
+//setSaveClicked 一時保存時にコメ欄が閉じていて、コメ欄黒帯共存が無効のとき
+//$(EXfootcome).on("click" コメ欄が閉じている＝開ける時で、黒帯が常時表示でなく、コメ欄黒帯共存が無効のとき
+//1s 隠すカウントダウンが0になったとき
+
+    var oclick=false; //overlayをクリックするかどうか
+    var comefix=false; //コメント欄の表示修正
+    if(inp.head!==undefined){
+        comefix=true;
+        if(inp.head==true){
+            EXhead.style.visibility="hidden";
+            EXhead.style.opacity="0";
+        }else if(inp.head==false){
+            if(EXhead.style.visibility=="hidden"){
+                EXhead.style.visibility="";
+            }
+            if(EXhead.style.opacity=="0"){
+                EXhead.style.opacity="";
+            }
+        }
     }
-    var contCome = $(EXcome);
-    var comeForm = $(EXcomesend);
-    var comeshown = $(EXcome).filter('[class*="TVContainer__right-slide--shown___"]').length>0?true:false;
-    var hideCommentParam = isCustomPostWin?64:108;
-    var clipSlideBarTop = ($(EXhead).css("visibility")=="visible")?44:0;
-    var clipSlideBarBot = ($(EXfoot).css("visibility")=="visible")?61:0;
-    var butscr = $(EXfoot).contents().find('button[class^="styles__full-screen___"]:first');
-    var butvol = $(EXvolume);
-    var itimeposi=($('#settcont').css("display")=="none")?(isTimeVisible?timePosition:""):($('#isTimeVisible').prop("checked")?$('#itimePosition [name="timePosition"]:checked').val():"");
-    var ititleposi=($('#settcont').css("display")=="none")?(isProtitleVisible?protitlePosition:""):($('#isProtitleVisible').prop("checked")?$('#iprotitlePosition [name="protitlePosition"]:checked').val():"");
-    var iprosame=($('#settcont').css("display")=="none")?proSamePosition:$('#iproSamePosition [name="proSamePosition"]:checked').val();
-    var timepadtop=(isTimeVisible&&(itimeposi=="windowtop")&&($(EXhead).css("visibility")=="hidden"))?15:0;
-    var timepadbot=(isTimeVisible&&(itimeposi=="windowbottom")&&($(EXfoot).css("visibility")=="hidden"))?15:0;
-    var titlepadtop=(isProtitleVisible&&(ititleposi=="windowtopright")&&($(EXhead).css("visibility")=="hidden"))?15:0;
-    var titlepadbot=(isProtitleVisible&&(ititleposi=="windowbottomright")&&($(EXfoot).css("visibility")=="hidden"))?15:0;
-    if(timepadtop==0||titlepadtop==0||iprosame=="vertical"){
-        timepadtop+=titlepadtop;
-        timepadbot+=titlepadbot;
+    if(inp.foot!==undefined){
+        comefix=true;
+        if(inp.foot==true){
+            EXfoot.style.visibility="hidden";
+            EXfoot.style.opacity="0";
+        }else if(inp.foot==false){
+            if(EXfoot.style.visibility=="hidden"){
+                EXfoot.style.visibility="";
+            }
+            if(EXfoot.style.opacity=="0"){
+                EXfoot.style.opacity="";
+            }
+        }
     }
-    contCome.css("transform",isSureReadComment?"translateX(0px)":"");
-    if(isInpWinBottom){
-        var b=80+((isSureReadComment||comeshown)?hideCommentParam:0);
-        butscr.css("bottom",b+"px");
-        butvol.css("bottom",b+"px");
-        if(comeList.css("display")=="none"){
-            contCome.css("position","absolute");
-            contCome.css("top",(window.innerHeight-hideCommentParam-clipSlideBarBot)+"px");
-            contCome.css("height",hideCommentParam+"px");
-            comeForm.css("position","absolute");
-            comeForm.css("top","");
-            comeForm.css("bottom",0);
-            comeForm.css("height",hideCommentParam+"px");
-            comeList.css("position","absolute");
-            comeList.css("width","100%");
+    if(inp.side==true){
+        EXside.style.transform="translate(100%, -50%)";
+    }else if(inp.foot==false){
+        if(EXside.style.transform=="translate(100%, -50%)"){
+            EXside.style.transform="";
+        }
+    }
+    if(inp.programinfo==true){
+        EXinfo.style.transform="translateX(100%)";
+    }else if(inp.programinfo==false){
+        if(EXinfo.style.transform=="translateX(100%)"){
+            EXinfo.style.transform="";
+        }
+    }else if(inp.programinfo=="force"){
+        EXinfo.style.transform="translateX(100%)";
+        oclick=true;
+    }
+    if(inp.channellist==true){
+        EXchli.parentElement.style.transform="translateX(100%)";
+    }else if(inp.channellist==false){
+        if(EXchli.parentElement.style.transform=="translateX(100%)"){
+            EXinfo.parentElement.style.transform="";
+        }
+    }else if(inp.channellist=="force"){
+        EXchli.parentElement.style.transform="translateX(100%)";
+        oclick=true;
+    }
+    if(inp.commentlist==true){
+        EXcome.style.transform="translateX(100%)";
+    }else if(inp.commentlist==false){
+        if(EXcome.style.transform=="translateX(100%)"){
+            EXcome.style.transform="";
+        }
+    }else if(inp.commentlist=="force"){
+        EXcome.style.transform="translateX(100%)";
+        oclick=true;
+    }
+    if(oclick){
+        $('[class^="style__overlap___"]').trigger("click");
+    }
+    if(comefix){
+        setTimeout(setProSamePosiChanged,110,true);
+    }
+}
+function popElement(inp){
+//trueなら積極的に表示するよう設定
+//falseはtrueの解除(trueの設定値どおりの時のみ機能するので、積極的に隠す場合はhideElementを使用する)
+//true,falseは見た目の変化のみで内部の開閉状態は変化しないので映像の横縮小などは変化しないはず
+//"force"なら各triggerで開こうとする（視聴中番組情報、放送中番組一覧、コメントリスト）
+//クリックによる影響（他要素の開閉やイベント）は全く考慮していない
+//音量ボタン等の高さ位置はここで調整
+    var comefix=false;
+    if(inp.head!==undefined){
+        comefix=true;
+        if(inp.head==true){
+            EXhead.style.visibility="visible";
+            EXhead.style.opacity="1";
+        }else if(inp.head==false){
+            if(EXhead.style.visibility=="visible"){
+                EXhead.style.visibility="";
+            }
+            if(EXhead.style.opacity=="1"){
+                EXhead.style.opacity="";
+            }
+        }
+    }
+    if(inp.foot!==undefined){
+        comefix=true;
+        if(inp.foot==true){
+            EXfoot.style.visibility="visible";
+            EXfoot.style.opacity="1";
+        }else if(inp.foot==false){
+            if(EXfoot.style.visibility=="visible"){
+                EXfoot.style.visibility="";
+            }
+            if(EXfoot.style.opacity=="1"){
+                EXfoot.style.opacity="";
+            }
+        }
+    }
+    if(inp.side==true){
+        EXside.style.transform="translateY(-50%)";
+    }else if(inp.foot==false){
+        if(EXside.style.transform=="translateY(-50%)"){
+            EXside.style.transform="";
+        }
+    }
+    if(inp.programinfo==true){
+        EXinfo.style.transform="translateX(0px)";
+    }else if(inp.programinfo==false){
+        if(EXinfo.style.transform=="translateX(0px)"){
+            EXinfo.style.transform="";
+        }
+    }else if(inp.programinfo=="force"){
+        EXinfo.style.transform="translateX(0px)";
+        $(EXfootcome).prev().not('[class*="styles__left-container-not-clickable___"]').trigger("click");
+    }
+    if(inp.channellist==true){
+        EXchli.parentElement.style.transform="translateX(0px)";
+    }else if(inp.channellist==false){
+        if(EXchli.parentElement.style.transform=="translateX(0px)"){
+            EXinfo.parentElement.style.transform="";
+        }
+    }else if(inp.channellist=="force"){
+        EXchli.parentElement.style.transform="translateX(0px)";
+        $(EXside).contents().find('button').eq(1).trigger("click");
+    }
+    if(inp.commentlist==true){
+        EXcome.style.transform="translateX(0px)";
+    }else if(inp.commentlist==false){
+        if(EXcome.style.transform=="translateX(0px)"){
+            EXcome.style.transform="";
+        }
+    }else if(inp.commentlist=="force"){
+        EXcome.style.transform="translateX(0px)";
+        $(EXfootcome).not('[class*="styles__right-container-not-clickable___"]').trigger("click");
+    }
+    if(comefix){
+        setTimeout(setProSamePosiChanged,110,true);
+    }
+}
+function comemarginfix(repeatcount,inptime,inptitle,inpsame,inpbig){
+//旧comevisiset
+//setProSamePosiChangedから呼ぶ
+//黒帯パネルとコメント欄が重なるのを防ぎ
+//番組残り時間とタイトルの分を考慮して入力欄周辺とコメ欄端のmarginを設定する
+//再試行はヘッダとフッタの開閉遅延を考慮
+    var jform=$(EXcomesend);
+    var jcome=$(EXcomesend).siblings(['class^="styles__comment-list-wrapper___"']);
+    var jfptop=0; //jformのpadding-top
+    var jfpbot=0;
+    var jfmtop=0; //jformのmargin-top
+    var jfmbot=0;
+    var jcmtop=0; //jcomeのmargin-top
+    var jcmbot=0;
+    var htime=isTimeVisible?$('#forProEndTxt').height():0;
+    var htitle=isProtitleVisible?$('#tProtitle').height():0;
+    var ptime=(inptime!==undefined)?inptime:(isTimeVisible?timePosition:"");
+    var ptitle=(inptitle!==undefined)?inptitle:(isProtitleVisible?protitlePosition:"");
+    var psame=(inpsame!==undefined)?inpsame:proSamePosition;
+    //画面上部の設定
+    if($(EXhead).css("visibility")=="visible"){
+        //ヘッダ表示時
+        if(isInpWinBottom){
+            //入力欄が下＝コメ欄が上＝対象はjcomeのtopmargin
+            if(ptime=="windowtop"&&ptitle=="windowtopright"&&psame=="vertical"){
+                jcmtop=Math.max(htime+htitle,44);
+            }else{
+                jcmtop=44;
+            }
         }else{
-            contCome.css("position","absolute");
-            contCome.css("top",(clipSlideBarTop+timepadtop)+"px");
-            contCome.css("height",(window.innerHeight-clipSlideBarTop-clipSlideBarBot-timepadtop)+"px");
-            comeForm.css("position","absolute");
-            comeForm.css("top","");
-            comeForm.css("bottom",0);
-            comeForm.css("height",hideCommentParam+"px");
-            comeList.css("position","absolute");
-            comeList.css("bottom","");
-            comeList.css("top",0);
-            comeList.css("height",(window.innerHeight-hideCommentParam-clipSlideBarTop-clipSlideBarBot-timepadtop)+"px");
-            comeList.css("width","100%");
+            //入力欄が上＝対象はjformのtopmargin＋番組情報(コメ上)
+            if(ptime=="windowtop"&&ptitle=="windowtopright"&&psame=="vertical"){
+                jfmtop=Math.max(htime+htitle,44);
+            }else{
+                jfmtop=44;
+            }
+            if(ptime=="commentinputtop"&&ptitle=="commentinputtopright"&&psame=="vertical"){//(ptitle=="commentinputtopleft"||
+                jfptop=Math.max(htime+htitle,15);
+            }else if(ptime=="commentinputtop"||(ptitle=="commentinputtopleft"||ptitle=="commentinputtopright")){
+                jfptop=Math.max(htime,htitle,15);
+            }else{
+                jfptop=15;
+            }
         }
     }else{
-        butscr.css("bottom","");
-        butvol.css("bottom","");
-        if(comeList.css("display")=="none"){
-            contCome.css("position","absolute");
-            contCome.css("top",clipSlideBarTop+"px");
-            contCome.css("height",hideCommentParam+"px");
-            comeForm.css("position","absolute");
-            comeForm.css("bottom","");
-            comeForm.css("top",0);
-            comeForm.css("height",hideCommentParam+"px");
-            comeList.css("position","absolute");
-            comeList.css("width","100%");
-        }else{
-            contCome.css("position","absolute");
-            contCome.css("top",clipSlideBarTop+"px");
-            contCome.css("height",(window.innerHeight-clipSlideBarTop-clipSlideBarBot-timepadbot)+"px");
-            comeForm.css("position","absolute");
-            comeForm.css("bottom","");
-            comeForm.css("top",0);
-            comeForm.css("height",hideCommentParam+"px");
-            comeList.css("position","absolute");
-            comeList.css("top","");
-            comeList.css("bottom",0);
-            comeList.css("height",(window.innerHeight-hideCommentParam-clipSlideBarTop-clipSlideBarBot-timepadbot)+"px");
-            comeList.css("width","100%");
+        //ヘッダ非表示時
+        if(isInpWinBottom){
+            if(ptime=="windowtop"&&ptitle=="windowtopright"&&psame=="vertical"){
+                jcmtop=htime+htitle;
+            }else if(ptime=="windowtop"||ptitle=="windowtopright"){
+                jcmtop=Math.max(htime,htitle);
+            }else{
+                jcmtop=0;
+            }
+        }else{ //jftop
+            var margincut=0;
+            if((ptime=="windowtop"||ptitle=="windowtopright")&&(ptime!="commentinputtop"&&ptitle!="commentinputtopright"&&ptitle!="commentinputtopleft")){
+                //ウィンドウ右上に何かあり、入力欄の上には何も無いとき
+                margincut=15;
+            }else if(ptime!="windowtop"&&ptitle!="windowtopright"){
+                //ウィンドウ右上には何も無いとき
+                margincut=15;
+            }
+            if(ptime=="windowtop"&&ptitle=="windowtopright"&&psame=="vertical"){
+                jfmtop=htime+htitle-margincut;
+            }else if(ptime=="windowtop"||ptitle=="windowtopright"){
+                jfmtop=Math.max(htime,htitle,15)-margincut;
+            }else{
+                jfmtop=15-margincut;
+            }
+            if(ptime=="commentinputtop"&&ptitle=="commentinputtopright"&&psame=="vertical"){//(ptitle=="commentinputtopleft"||
+                jfptop=Math.max(htime+htitle,15);
+            }else if(ptime=="commentinputtop"||(ptitle=="commentinputtopleft"||ptitle=="commentinputtopright")){
+                jfptop=Math.max(htime,htitle,15);
+            }else{
+                jfptop=15;
+            }
         }
     }
-    proPositionAllReset()
-    setProtitlePosition("","",true);
-    setTimePosition("","",true);
-    proSamePositionFix();
-}
-function unpopElement(){
-//console.log("unpopElement");
-    popElemented=false;
-    $(EXinfo).css("z-index","");
-    $(EXside).css("transform","");
-    $(EXchli).parent().css("z-index","");
-    $(EXhead).css("visibility","")
-      .css("opacity","")
+    //フッタ表示かつコメ入力下の場合は音量ボタン等の下位置を上げる
+    var volshift=false;
+    $(EXvolume).css("bottom","")
+        .prev('[class^="styles__full-screen___"]').css("bottom","")
     ;
-    $(EXfoot).css("visibility","")
-      .css("opacity","")
+    if($(EXfoot).css("visibility")=="visible"){
+        //フッタ表示時
+        if(isInpWinBottom){ // jctop,jfbot
+            volshift=true;
+            jfmbot=$(EXfoot).children('[class^="TVContainer__footer___"]').height();
+            if(ptime=="commentinputbottom"&&ptitle=="commentinputbottomright"&&psame=="vertical"){//(ptitle=="commentinputbottomleft"||
+                jfpbot=Math.max(htime+htitle,15);
+            }else if(ptime=="commentinputbottom"||(ptitle=="commentinputbottomleft"||ptitle=="commentinputbottomright")){
+                jfpbot=Math.max(htime,htitle,15);
+            }else{
+                jfpbot=15;
+            }
+        }else{ // jftop,jcbot
+            jcmbot=$(EXfoot).children('[class^="TVContainer__footer___"]').height();
+        }
+    }else{
+        //フッタ非表示時
+        if(isInpWinBottom){ // jctop,jfbot
+            var margincut=0;
+            if((ptime=="windowbottom"||ptitle=="windowbottomright")&&(ptime!="commentinputbottom"&&ptitle!="commentinputbottomright"&&ptitle!="commentinputbottomleft")){
+                //ウィンドウ右下に何かあり、入力欄の下には何も無いとき
+                margincut=15;
+            }else if(ptime!="windowbottom"&&ptitle!="windowbottomright"){
+                //ウィンドウ右下には何も無いとき
+                margincut=15;
+            }
+            if(ptime=="windowbottom"&&ptitle=="windowbottomright"&&psame=="vertical"){
+                jfmbot=htime+htitle-margincut;
+            }else if(ptime=="windowbottom"||ptitle=="windowbottomright"){
+                jfmbot=Math.max(htime,htitle,15)-margincut;
+            }else{
+                jfmbot=15-margincut;
+            }
+            if(ptime=="commentinputbottom"&&ptitle=="commentinputbottomright"&&psame=="vertical"){//(ptitle=="commentinputbottomleft"||
+                jfpbot=Math.max(htime+htitle,15);
+            }else if(ptime=="commentinputbottom"||(ptitle=="commentinputbottomleft"||ptitle=="commentinputbottomright")){
+                jfpbot=Math.max(htime,htitle,15);
+            }else{
+                jfpbot=15;
+            }
+        }else{ // jftop,jcbot
+            if(ptime=="windowbottom"&&ptitle=="windowbottomright"&&psame=="vertical"){
+                jcmbot=htime+htitle;
+            }else if(ptime=="windowbottom"||ptitle=="windowbottomright"){
+                jcmbot=Math.max(htime,htitle);
+            }else{
+                jcmbot=0;
+            }
+        }
+    }
+    if(isInpWinBottom){ //jctop,jfbot,jftop
+        if(ptime=="commentinputtop"&&ptitle=="commentinputtopright"&&psame=="vertical"){//(ptitle=="commentinputtopleft"||
+            jfptop=Math.max(htime+htitle,15);
+        }else if(ptime=="commentinputtop"||(ptitle=="commentinputtopleft"||ptitle=="commentinputtopright")){
+            jfptop=Math.max(htime,htitle,15);
+        }else{
+            jfptop=15;
+        }
+    }else{ //jftop,jcbot,jfbot
+        if(ptime=="commentinputbottom"&&ptitle=="commentinputbottomright"&&psame=="vertical"){//(ptitle=="commentinputbottomleft"||
+            jfpbot=htime+htitle;
+        }else if(ptime=="commentinputbottom"||(ptitle=="commentinputbottomleft"||ptitle=="commentinputbottomright")){
+            jfpbot=Math.max(htime,htitle,15);
+        }else{
+            jfpbot=15;
+        }
+    }
+    jform.css("margin-top",jfmtop)
+        .css("margin-bottom",jfmbot)
+        .css("padding-top",jfptop)
+        .css("padding-bottom",jfpbot)
     ;
-//    if(!isSureReadComment){
-    $(EXcome).css("transform","")
-//        .css("position","")
-      ;
-//    }
-//console.log("comevisiset unpopElement");
-//    comevisiset(false);
-    waitforhide(10);
+    jcome.css("margin-top",jcmtop)
+        .css("margin-bottom",jcmbot)
+    ;
+    if(volshift){
+        $(EXvolume).css("bottom",(80+34+jfptop+jfpbot)+"px")
+            .prev('[class^="styles__full-screen___"]').css("bottom",(80+34+jfptop+jfpbot)+"px")
+        ;
+    }
+    if(repeatcount>0){
+        setTimeout(comemarginfix,210,repeatcount-1,inptime,inptitle,inpsame,inpbig);
+    }
 }
-function popElement(){
+//function unpopElement(){
+////console.log("unpopElement");
+//    popElemented=false;
+//    $(EXinfo).css("z-index","");
+//    $(EXside).css("transform","");
+//    $(EXchli).parent().css("z-index","");
+//    $(EXhead).css("visibility","")
+//      .css("opacity","")
+//    ;
+//    $(EXfoot).css("visibility","")
+//      .css("opacity","")
+//    ;
+////    if(!isSureReadComment){
+//    $(EXcome).css("transform","")
+////        .css("position","")
+//      ;
+////    }
+////console.log("comevisiset unpopElement");
+////    comevisiset(false);
+////    waitforhide(10);
+//    $(EXcomesend).css("margin","")
+//        .siblings(['class^="styles__comment-list-wrapper___"']).css("margin","")
+//    ;
+//}
+//function popElement(){
 //console.log("popElement");
-    popElemented=true;
-    //マウスオーバーで各要素表示
-    $(EXinfo).css("z-index",11); //コメ欄が10なのでそれより上へ
-    $(EXside).css("transform","translate(0,-50%)");
-    $(EXchli).parent().css("z-index",11);
-    $(EXhead).css("visibility","visible")
-      .css("opacity",1)
-    ;
-    $(EXfoot).css("visibility","visible")
-      .css("opacity",1)
-    ;
-    $(EXcome).css("transform","translateX(0px)")
-//      .css("position","absolute")
-    ;
-//console.log("comevisiset popElement");
-//    comevisiset(false);
-    waitforpop(10);
-}
+//    popElemented=true;
+//    //マウスオーバーで各要素表示
+//    $(EXinfo).css("z-index",11); //コメ欄が10なのでそれより上へ
+//    $(EXside).css("transform","translate(0,-50%)");
+//    $(EXchli).parent().css("z-index",11);
+//    $(EXhead).css("visibility","visible")
+//      .css("opacity",1)
+//    ;
+//    $(EXfoot).css("visibility","visible")
+//      .css("opacity",1)
+//    ;
+//    $(EXcome).css("transform","translateX(0px)")
+////      .css("position","absolute")
+//    ;
+////console.log("comevisiset popElement");
+////    comevisiset(false);
+////    waitforpop(10);
+//}
 function setEXs(){
     var b=true;
     if((EXmain=$('#main')[0])==null){b=false;}
-    else if((EXhead=$('[class^="AppContainer__header-container___"]:first')[0])==null){b=false;}
-    else if((EXfoot=$('[class^="TVContainer__footer-container___"]:first')[0])==null){b=false;console.log("foot");}
-    else if((EXfootcome=$(EXfoot).contents().find('[class*="styles__right-container"]:first')[0])==null){b=false;console.log("footcome");}
+    else if((EXhead=$('[class^="AppContainer__header-container___"]')[0])==null){b=false;}
+    else if((EXfoot=$('[class^="TVContainer__footer-container___"]')[0])==null){b=false;console.log("foot");}
+    else if((EXfootcome=$(EXfoot).contents().find('[class*="styles__right-container"]')[0])==null){b=false;console.log("footcome");}
     else if((EXfootcount=$(EXfoot).contents().find('[class*="styles__counter___"]'))==null){b=false;console.log("footcount");}
     else if((EXfootcountview=EXfootcount[0])==null){b=false;console.log("footcountview");}
     else if((EXfootcountcome=EXfootcount[1])==null){b=false;console.log("footcountcome");}
-    else if((EXside=$('[class^="TVContainer__side___"]:first')[0])==null){b=false;console.log("side");}
-    else if((EXchli=$('[class*="TVContainer__right-v-channel-list___"]:first')[0])==null){b=false;console.log("chli");}
-    else if((EXinfo=$('[class^="TVContainer__right-slide___"]:first')[0])==null){b=false;console.log("info");}
-    else if((EXcome=$('[class^="TVContainer__right-comment-area___"]:first')[0])==null){b=false;console.log("come");}
-    else if((EXcomesend=$(EXcome).contents().find('[class*="styles__comment-form___"]:first')[0])==null){b=false;console.log("comesend");}
-    else if((EXcomesendinp=$(EXcomesend).contents().find('textarea:first')[0])==null){b=false;console.log("comesendinp");}
+    else if((EXside=$('[class^="TVContainer__side___"]')[0])==null){b=false;console.log("side");}
+    else if((EXchli=$('[class*="TVContainer__right-v-channel-list___"]')[0])==null){b=false;console.log("chli");}
+    else if((EXinfo=$('[class^="TVContainer__right-slide___"]')[0])==null){b=false;console.log("info");}
+    else if((EXcome=$('[class^="TVContainer__right-comment-area___"]')[0])==null){b=false;console.log("come");}
+    else if((EXcomesend=$(EXcome).contents().find('[class*="styles__comment-form___"]')[0])==null){b=false;console.log("comesend");}
+    else if((EXcomesendinp=$(EXcomesend).contents().find('textarea')[0])==null){b=false;console.log("comesendinp");}
 //    else if((EXcomelist0=$($(EXcome).contents().find('[class^="styles__no-contents-text___"]:first')[0]).parent()[0])==null){b=false;console.log("comelist");}
-    else if((EXvolume=$('[class^="styles__volume___"]:first')[0])==null){b=false;console.log("vol");}
-    else if((EXobli=$('[class*="TVContainer__tv-container___"]:first')[0])==null){b=false;console.log("obli");}
+    else if((EXvolume=$('[class^="styles__volume___"]')[0])==null){b=false;console.log("vol");}
+    else if((EXobli=$('[class*="TVContainer__tv-container___"]')[0])==null){b=false;console.log("obli");}
     if(b==true){
 console.log("setEXs ok");
         setEX2();
@@ -1357,11 +1814,11 @@ console.log("setEXs retry");
 }
 function setEX2(){
     var b=true;
-    if($(EXchli).children('[class*="styles__watch___"]:first').length==0){b=false;}
-    else if((EXwatchingstr=$(EXchli).children('[class*="styles__watch___"]:first').contents().find('img').prop("alt"))==null){b=false;}
+    if($(EXchli).children('[class*="styles__watch___"]').length==0){b=false;}
+    else if((EXwatchingstr=$(EXchli).children('[class*="styles__watch___"]').contents().find('img').prop("alt"))==null){b=false;}
     else if((EXwatchingnum=$(EXobli).contents().find('img[alt='+EXwatchingstr+']').parents().index())==null){b=false;}
     else{
-        $(EXchli).parent().scrollTop($(EXchli).children('[class*="styles__watch___"]:first').index()*85-$(EXside).position().top);
+        $(EXchli).parent().scrollTop($(EXchli).children('[class*="styles__watch___"]').index()*85-$(EXside).position().top);
     }
     if(b==true){
 console.log("setEX2 ok");
@@ -1371,10 +1828,12 @@ console.log("setEX2 retry");
     }
 }
 function isComeOpen(){
-    return ($(EXcome).filter('[class*="TVContainer__right-slide--shown___"]').length==1)?true:false;
+//    return ($(EXcome).filter('[class*="TVContainer__right-slide--shown___"]').length==1)?true:false;
+    return $(EXcome).is('[class*="TVContainer__right-slide--shown___"]');
 }
 function isSlideShown(){
-    return ($(EXcome).siblings('[class*="TVContainer__right-slide--shown___"]').length==1)?true:false;
+//    return ($(EXcome).siblings('[class*="TVContainer__right-slide--shown___"]').length==1)?true:false;
+    return ($(EXcome).siblings('[class*="TVContainer__right-slide--shown___"]').length>0)?true:false;
 }
 //function getComeId(inp){
 //    return parseInt(/.*\$(\d+)$/.exec(EXcomelist.children[inp].getAttribute("data-reactid"))[1]);
@@ -1402,34 +1861,34 @@ function otosageru(){
     if(!EXvolume){return;}
     var teka=document.createEvent("MouseEvents");
 //    var teki=$('[class^="styles__slider-container___"]').children();
-    var teki=$(EXvolume).contents().find('[class^="styles__slider-container___"]:first').children();
-    var teku=teki.offset().top+106-Math.min(92,Math.max(0,Math.floor(92*changeMaxVolume/100)));
+    var teki=$(EXvolume).contents().find('[class^="styles__slider-container___"]').children();
+    var targetvolume=Math.min(92,Math.max(0,Math.floor(92*changeMaxVolume/100)));
+    var teku=teki.offset().top+106-targetvolume;
     teka.initMouseEvent("mousedown",true,true,window,0,0,0,teki.offset().left+15,teku);
-    setTimeout(otomouseup,100);
+    setTimeout(otomouseup,100,teku);
     return teki[0].dispatchEvent(teka);
 }
 function moVol(d){
     if(!EXvolume){return;}
     var teka=document.createEvent("MouseEvents");
-    var teki=$(EXvolume).contents().find('[class^="styles__slider-container___"]:first').children();
-    var teku=teki.offset().top+106;
-    var teke=parseInt($(EXvolume).contents().find('[class^="styles__highlighter___"]:first').css("height"));
-    teke=(teke+d>91)?91:(teke+d<0)?0:(teke+d);
-    teka.initMouseEvent("mousedown",true,true,window,0,0,0,teki.offset().left+15,teku-teke);
-    setTimeout(otomouseup,100);
+    var teki=$(EXvolume).contents().find('[class^="styles__slider-container___"]').children();
+    var orivol=parseInt($(EXvolume).contents().find('[class^="styles__highlighter___"]').css("height"));
+    var targetvolume=Math.min(91,Math.max(0,orivol+d));
+    var teku=teki.offset().top+106-targetvolume;
+    teka.initMouseEvent("mousedown",true,true,window,0,0,0,teki.offset().left+15,teku);
+    setTimeout(otomouseup,100,teku);
     return teki[0].dispatchEvent(teka);
 }
-function otomouseup(){
+function otomouseup(p){
     if(!EXvolume){return;}
     var teka=document.createEvent("MouseEvents");
-    var teki=$(EXvolume).contents().find('[class^="styles__slider-container___"]:first').children();
-    var teku=teki.offset().top+106;
-    var teke=parseInt($(EXvolume).contents().find('[class^="styles__highlighter___"]:first').css("height"));
-    teka.initMouseEvent("mouseup",true,true,window,0,0,0,teki.offset().left+15,teku-teke);
+    var teki=$(EXvolume).contents().find('[class^="styles__slider-container___"]').children();
+    teka.initMouseEvent("mouseup",true,true,window,0,0,0,teki.offset().left+15,p);
+    setTimeout(volbar,100);
     return teki[0].dispatchEvent(teka);
 }
 function otoColor(){
-    var jo=$(EXvolume).contents().find('svg:first');
+    var jo=$(EXvolume).contents().find('svg');
     if(jo.length==0){return;}
     if(jo.css("fill")=="rgb(255, 255, 255)"){
         jo.css("fill","red");
@@ -1439,7 +1898,7 @@ function otoColor(){
     }
 }
 function otoSize(ts){
-    var jo=$(EXvolume).contents().find('svg:first');
+    var jo=$(EXvolume).contents().find('svg');
     if(jo.length==0){return;}
     if(jo.css("zoom")=="1"){
         jo.css("zoom",ts);
@@ -1448,24 +1907,51 @@ function otoSize(ts){
         jo.css("zoom","");
     }
 }
-function faintcheck2(retrycount,fcd){
-    var pwaku = $('[class^="style__overlap___"]'); //動画枠
+function volbar(){
+    var jo=$('#forProEndTxt');
+    if(jo.filter('.forProEndTxt').length==0){
+        jo.prop("class","forProEndTxt");
+    }else{
+        jo.prop("class","");
+        var orivol=parseInt($(EXvolume).contents().find('[class^="styles__highlighter___"]').css("height"));
+        var v=Math.min(92,Math.max(0,orivol));
+        var p=Math.min(99,Math.round(100*v/92));
+        var q=(v==0)?"mute":(p+"%");
+        var w=1+Math.round(309*v/92);
+        jo.text("vol "+q);
+        $('#forProEndBk').css("width",w+"px");
+        setTimeout(volbar,800);
+    }
+}
+function faintcheck2(retrycount,fcd,sw){
+//console.log("faintcheck#"+retrycount+",fcd="+fcd);
+//    var pwaku = $('[class^="style__overlap___"]'); //動画枠
 //  var come = $('[class*="styles__counter___"]'); //画面右下のカウンター
-    if(pwaku[0]&&EXfootcountcome){
-        if(isNaN(parseInt($(EXfootcountcome).text()))){
-            cmblockcd=fcd;
-            return;
+//    if(pwaku[0]&&EXfootcountcome){
+    if(EXfootcountcome){
+        if(sw<0){
+            if(isNaN(parseInt($(EXfootcountcome).text()))){
+//console.log("faintcheck cmblockcd="+cmblockcd+"->"+fcd);
+                cmblockcd=fcd;
+                return;
+            }
+        }else if(sw>0){
+            if(!isNaN(parseInt($(EXfootcountcome).text()))){
+//console.log("faintcheck cmblockcd="+cmblockcd+"->"+fcd);
+                cmblockcd=fcd;
+                return;
+            }
         }
     }
     if(retrycount>0){
         setTimeout(faintcheck2,150,retrycount-1,fcd);
     }
 }
-function faintcheck(fcd){
-    if(fcd>0){
-        faintcheck2(5,Math.max(1,fcd));
-    }else if(fcd<0){
-        faintcheck2(5,Math.min(-1,fcd));
+function faintcheck(fcd,sw){
+    if(sw>0){
+        faintcheck2(5,Math.max(0,fcd),sw);
+    }else if(sw<0){
+        faintcheck2(5,Math.min(0,fcd),sw);
     }
 }
 function comeColor(inp){
@@ -1511,7 +1997,7 @@ function waitforOpenCome(retrycount){
     }
 }
 function waitforOpenableCome(retrycount){
-    if(!isSlideShown()&&$(EXfootcome).filter('[class*="styles__right-container-not-clickable___"]').length==0){
+    if(!isSlideShown()&&!$(EXfootcome).is('[class*="styles__right-container-not-clickable___"]')){
 //    if($(EXfootcome).filter('[class*="styles__right-container-not-clickable___"]').length==0){
         $(EXfootcome).trigger("click");
 //console.log("comeopen waitforopenable");
@@ -1530,60 +2016,110 @@ function waitforCloseCome(retrycount){
 function fastRefreshing(){
     waitforCloseCome(100);
 }
-function proPositionAllReset(){
+//function proFontChange(timepar,titlepar,samepar){
+//    var prehoverContents = $('[class*="styles__hover-contents___"]').parent();
+//    var headlogo=prehoverContents.siblings().first();
+//    var parexfootcount=$(EXfootcount).parent();
+//    var footlogo=$(EXfoot).contents().find('[class*="styles__channel-logo___"]').first();
+//    var forpros=$("#forProEndTxt,#forProEndBk,#proTimeEpNum");
+//    var tpro=$("#tProtitle");
+//    switch(titlepar){
+//        case "windowtopleft":
+//        case "headerleft":
+//            tpro.css("font-size","medium");
+//            headlogo.css("padding-top","9px")
+//                .next().css("padding-top","9px")
+//            ;
+//            break;
+/////        case "windowbottomleft":
+//        case "footerleft":
+//            tpro.css("font-size","medium");
+//            footlogo.css("padding-bottom","18px")
+//                .next().css("padding-bottom","18px")
+//            ;
+//            break;
+//        case "windowtopright":
+//        case "headerright":
+//            if(timepar!="windowtop"&&timepar!="header"||samepar=="horizontal"){
+//                tpro.css("font-size","medium");
+//                prehoverContents.css("padding-top","12px")
+//                    .prev().css("padding-top","12px")
+//                ;
+//            }
+//            break;
+//    }
+////    if(titlepar=="window$(EXhead).css("visibility")=="visible")
+//}
+function proPositionAllReset(bigtext){
 //console.log("proSameUnFix");
     var prehoverContents = $('[class*="styles__hover-contents___"]').parent();
     var headlogo=prehoverContents.siblings().first();
     var parexfootcount=$(EXfootcount).parent();
     var footlogo=$(EXfoot).contents().find('[class*="styles__channel-logo___"]').first();
-    var forpros=$("#forProEndTxt,#forProEndBk");
+    var forpros=$("#forProEndTxt,#forProEndBk,#proTimeEpNum");
+    var bsize=(bigtext!==undefined)?bigtext:isProTextLarge;
+    var fsize=bsize?"medium":"x-small";
     var tpro=$("#tProtitle");
-    tpro.css("overflow","")
-        .css("width","")
-        .css("text-align","")
+//    tpro.css("overflow","")
+//        .css("width","")
+//        .css("text-align","")
+    tpro.css("transform","")
         .css("left","")
         .css("right","")
         .css("top","")
         .css("bottom","")
+        .css("font-size",fsize)
     ;
 //    forpros.css("left","")
 //        .css("right","")
     forpros.css("top","")
         .css("bottom","")
+        .css("font-size",fsize)
     ;
-    prehoverContents.css("padding-top","")
-        .prev().css("padding-top","")
+    prehoverContents.css("margin-top","")
+        .css("transform","")
+        .css("margin-left","")
+        .prev().css("margin-top","")
+        .css("transform","")
+        .contents().find('li').slice(1).css("margin-left","")
     ;
 //console.log("windowTR.pad=0 unfix");
-    headlogo.css("padding-top","")
-        .next().css("padding-top","")
+    headlogo.css("margin-top","")
+        .next().css("margin-top","")
     ;
 //console.log("windowTL.pad=0 unfix");
-    parexfootcount.css("padding-bottom","");
+    parexfootcount.css("margin-bottom","")
+        .css("height","")
+    ;
+    $(EXfootcome).css("border-left","")
+        .prev().css("border-right","")
+    ;
 //console.log("windowBR.pad=0 unfix");
-    footlogo.css("padding-bottom","")
-        .next().css("padding-bottom","")
+    footlogo.css("margin-bottom","")
+        .next().css("margin-bottom","")
     ;
 //console.log("windowBL.pad=0 unfix");
-    $(EXfootcome).next('#timerthird').remove();
+//    $(EXfootcome).next('#timerthird').remove();
 }
-//function proSamePositionFix(inptime,inptitle,inpsame){
-function proSamePositionFix(){
-//    if(!inptime||inptime==""){inptime=($('#settcont').css("display")=="none")?(isTimeVisible?timePosition:""):($('#isTimeVisible').prop("checked")?$('#itimePosition [name="timePosition"]:checked').val():"");}
-//    if(!inptitle||inptitle==""){inptitle=($('#settcont').css("display")=="none")?(isProtitleVisible?protitlePosition:""):($('#isProtitleVisible').prop("checked")?$('#iprotitlePosition [name="protitlePosition"]:checked').val():"");}
+//function proSamePositionFix(){
+function proSamePositionFix(inptime,inptitle,inpsame,inpbig){
+//    if(!inptime||inptime==""){inptime=($('#settcont').css("display")=="none")?(isTimeVisible?timePosition:""):($('#isTimeVisible').prop("checked")?$('#itimePosition input[type="radio"][name="timePosition"]:checked').val():"");}
+//    if(!inptitle||inptitle==""){inptitle=($('#settcont').css("display")=="none")?(isProtitleVisible?protitlePosition:""):($('#isProtitleVisible').prop("checked")?$('#iprotitlePosition input[type="radio"][name="protitlePosition"]:checked').val():"");}
 //    if(!inptime||inptime==""){inptime=timePosition;}
 //    if(!inptitle||inptitle==""){inptitle=protitlePosition;}
-    var inptime=($('#settcont').css("display")=="none")?(isTimeVisible?timePosition:""):($('#isTimeVisible').prop("checked")?$('#itimePosition [name="timePosition"]:checked').val():"");
-    var inptitle=($('#settcont').css("display")=="none")?(isProtitleVisible?protitlePosition:""):($('#isProtitleVisible').prop("checked")?$('#iprotitlePosition [name="protitlePosition"]:checked').val():"");
-    var inpsame=($('#settcont').css("display")=="none")?proSamePosition:$('#iproSamePosition [name="proSamePosition"]:checked').val();
-//console.log("proSameFix inptime:"+inptime+", inptitle:"+inptitle);
+//    var inptime=($('#settcont').css("display")=="none")?(isTimeVisible?timePosition:""):($('#isTimeVisible').prop("checked")?$('#itimePosition input[type="radio"][name="timePosition"]:checked').val():"");
+//    var inptitle=($('#settcont').css("display")=="none")?(isProtitleVisible?protitlePosition:""):($('#isProtitleVisible').prop("checked")?$('#iprotitlePosition input[type="radio"][name="protitlePosition"]:checked').val():"");
+//    var inpsame=($('#settcont').css("display")=="none")?proSamePosition:$('#iproSamePosition input[type="radio"][name="proSamePosition"]:checked').val();
+//console.log("proSameFix time="+inptime+", title="+inptitle+", same="+inpsame);
     var prehoverContents = $('[class*="styles__hover-contents___"]').parent();
     var headlogo=prehoverContents.siblings().first();
     var parexfootcount=$(EXfootcount).parent();
     var footlogo=$(EXfoot).contents().find('[class*="styles__channel-logo___"]').first();
-    var forpros=$("#forProEndTxt,#forProEndBk");
+    var forpros=$("#forProEndTxt,#forProEndBk,#proTimeEpNum");
+    var forprot=$("#forProEndTxt");
     var tpro=$("#tProtitle");
     var timeshown=inptime;
+    var bigtext=(inpbig!==undefined)?bigtext:isProTextLarge;
     if(timeshown=="header"){
         if($(EXhead).css("visibility")=="visible"){
             timeshown="windowtop";
@@ -1615,65 +2151,119 @@ function proSamePositionFix(){
     if(timeshown=="windowtop"&&titleshown=="windowtopright"){
         switch(inpsame){
             case "over":
-                tpro.css("overflow","hidden")
-                    .css("width","310px")
-                    .css("text-align","left")
+//                tpro.css("overflow","hidden")
+//                    .css("width","310px")
+//                    .css("text-align","left")
+                tpro.css("right","310px")
+                    .css("transform","translateX(100%)")
                 ;
                 break;
             case "vertical":
-                if(!isInpWinBottom&&$(EXhead).css("visibility")=="hidden"&&isComeOpen()){
-                    tpro.css("overflow","hidden")
-                        .css("width","310px")
-                        .css("text-align","left")
-                    ;
-                }else{
-                    forpros.css("top","15px");
-                    prehoverContents.css("padding-top","16px")
-                        .prev().css("padding-top","16px")
-                    ;
+//                if(!isInpWinBottom&&$(EXhead).css("visibility")=="hidden"&&isComeOpen()){
+//                    tpro.css("overflow","hidden")
+//                        .css("width","310px")
+//                        .css("text-align","left")
+//                    ;
+//                    tpro.css("right","310px")
+//                        .css("transform","translateX(100%)")
+//                    ;
+//                }else{
+                forpros.css("top",tpro.height()+"px");
+                prehoverContents.css("margin-top","")
+                    .css("transform","translateX(-310px)")
+                    .css("margin-left","12px")
+                    .prev().css("margin-top","")
+                    .css("transform","translateX(-310px)")
+                    .contents().find('li').slice(1).css("margin-left","12px")
+                ;
 //console.log("windowTR.pad=16 fix");
-                }
+//                }
                 break;
             case "horizontal":
                 tpro.css("right","310px");
+                break;
+            case "horizshort":
+                tpro.css("right",(forprot.width()+16)+"px");
                 break;
             default:
         }
     }else if(timeshown=="windowbottom"&&titleshown=="windowbottomright"){
         switch(inpsame){
             case "over":
-                tpro.css("overflow","hidden")
-                    .css("width","310px")
-                    .css("text-align","left")
+//                tpro.css("overflow","hidden")
+//                    .css("width","310px")
+//                    .css("text-align","left")
+                tpro.css("right","310px")
+                    .css("transform","translateX(100%)")
                 ;
                 break;
             case "vertical":
-                if(isInpWinBottom&&$(EXfoot).css("visibility")=="hidden"&&isComeOpen()){
-                    tpro.css("overflow","hidden")
-                        .css("width","310px")
-                        .css("text-align","left")
-                    ;
-                }else{
-                    tpro.css("bottom","15px");
-                    parexfootcount.css("padding-bottom","28px");
-//console.log("windowBR.pad=28 fix");
-                }
+//                if(isInpWinBottom&&$(EXfoot).css("visibility")=="hidden"&&isComeOpen()){
+//                    tpro.css("overflow","hidden")
+//                        .css("width","310px")
+//                        .css("text-align","left")
+//                tpro.css("right","310px")
+//                    .css("transform","translateX(100%)")
+//                ;
+//                }else{
+                tpro.css("bottom",forpros.height()+"px");
+                parexfootcount.css("margin-bottom","45px")
+                    .css("height","unset")
+                ;
+                $(EXfootcome).css("border-left","1px solid #444")
+                    .prev().css("border-right","none")
+                ;
+//console.log("windowBR.pad=31 fix");
+//                }
                 break;
             case "horizontal":
                 tpro.css("right","310px");
                 break;
+            case "horizshort":
+                tpro.css("right",(forprot.width()+16)+"px");
+                break;
             default:
         }
     }else if(timeshown=="commentinputtop"&&titleshown=="commentinputtopright"){
-        tpro.css("overflow","hidden")
-            .css("width","310px")
-            .css("text-align","left")
-        ;
+        switch(inpsame){
+            case "over":
+            case "horizontal":
+//        tpro.css("overflow","hidden")
+//            .css("width","310px")
+//            .css("text-align","left")
+                tpro.css("right","")
+                    .css("left",0)
+//                .css("transform","translateX(100%)")
+                ;
+                break;
+            case "vertical":
+                forpros.css("top",tpro.height()+"px");
+                break;
+            case "horizshort":
+                tpro.css("right",(forprot.width()+16)+"px");
+                break;
+            default:
+        }
     }else if(timeshown=="commentinputbottom"&&titleshown=="commentinputbottomright"){
-        tpro.css("overflow","hidden")
-            .css("width","310px")
-            .css("text-align","left")
-        ;
+        switch(inpsame){
+            case "over":
+            case "horizontal":
+//        tpro.css("overflow","hidden")
+//            .css("width","310px")
+//            .css("text-align","left")
+                tpro.css("right","")
+                    .css("left",0)
+//                .css("transform","translateX(100%)")
+                ;
+                break;
+            case "vertical":
+                tpro.css("bottom",forpros.height()+"px");
+                break;
+            case "horizshort":
+                tpro.css("right",(forprot.width()+16)+"px");
+                break;
+            default:
+        }
     }
 }
 function openInfo(sw){
@@ -1686,14 +2276,14 @@ function openInfo(sw){
         proinfoOpened=false;
     }
 }
-function createProtitle(sw,posiset){
+function createProtitle(sw,bt){
     if(!EXcome){return;}
     if(sw==0){
         if($("#tProtitle").length==0){
            var eProtitle = document.createElement("span");
             eProtitle.id="tProtitle";
-            eProtitle.setAttribute("style","position:absolute;right:0;font-size:x-small;padding:0px 8px;color:rgba(255,255,255,0.8);text-align:right;letter-spacing:1px;z-index:20;background-color:transparent;top:0px;");
-            eProtitle.innerHTML="&nbsp;";
+            eProtitle.setAttribute("style","position:absolute;right:0;font-size:"+(bt?"medium":"x-small")+";padding:0px 8px;color:rgba(255,255,255,0.8);text-align:right;letter-spacing:1px;z-index:19;background-color:transparent;top:0px;");
+            eProtitle.innerHTML="未取得";
             EXcome.insertBefore(eProtitle,EXcome.firstChild);
             //番組名クリックで番組情報タブ開閉
             $("#tProtitle").on("click",function(){
@@ -1705,15 +2295,12 @@ function createProtitle(sw,posiset){
                 }
             });
         }
-        if(posiset){
-            setProtitlePosition();
-        }
     }else if(sw==1){
         var prehoverContents = $('[class*="styles__hover-contents___"]').prev();
         var headlogo=prehoverContents.siblings().first();
         var parexfootcount=$(EXfootcount).parent();
         var footlogo=$(EXfoot).contents().find('[class*="styles__channel-logo___"]').first();
-        var forpros=$("#forProEndTxt,#forProEndBk");
+        var forpros=$("#forProEndTxt,#forProEndBk,#proTimeEpNum");
         prehoverContents.css("padding-top","")
             .prev().css("padding-top","")
         ;
@@ -1725,21 +2312,26 @@ function createProtitle(sw,posiset){
         $("#tProtitle").remove();
     }
 }
-function setProtitlePosition(timepar,par,subfunc){
+function setProtitlePosition(timepar,titlepar,samepar,bigpar){
 //console.log("setProtitle timepar:"+timepar+", par:"+par+", sub:"+(subfunc?"true":"false"));
-    if(!subfunc){
-        proPositionAllReset();
-        setTimePosition(timepar,par,true);
-    }
     //残り時間との重なり処理はこれが終わってから
-    if(!par||par==""){par=($('#settcont').css("display")=="none")?protitlePosition:$('#iprotitlePosition [name="protitlePosition"]:checked').val();}
-    if(!timepar||timepar==""){timepar=($('#settcont').css("display")=="none")?timePosition:$('#itimePosition [name="timePosition"]:checked').val();}
+//    if(!titlepar||titlepar==""){
+//        titlepar=isProtitleVisible?protitlePosition:"";
+//    }
+//    if(!timepar||timepar==""){
+//        timepar=isTimeVisible?timePosition:"";
+//    }
+//    if(!samepar||samepar==""){
+//        samepar=proSamePosition;
+//    }
 //console.log("setProtitle timepar:"+timepar+", par:"+par+", sub:"+(subfunc?"true":"false"));
     var prehoverContents = $('[class*="styles__hover-contents___"]').parent();
     var headlogo=prehoverContents.siblings().first();
     var parexfootcount=$(EXfootcount).parent();
     var footlogo=$(EXfoot).contents().find('[class*="styles__channel-logo___"]').first();
     var tpro=$("#tProtitle");
+    var bigtext=(bigpar!==undefined)?bigpar:isProTextLarge;
+    var par=titlepar;
     switch(par){
         case "windowtopleft":
         case "windowtopright":
@@ -1789,9 +2381,9 @@ function setProtitlePosition(timepar,par,subfunc){
     switch(par){
         case "windowtopright":
         case "headerright":
-            prehoverContents.css("padding-top","9px")
-                .prev().css("padding-top","9px")
-            ;
+            prehoverContents.css("margin-top",(bigtext?14:9)+"px")
+                .prev().css("margin-top",(bigtext?14:9)+"px")
+//            ;
 //console.log("windowTR.pad=9 setTitle("+(subfunc?"sub":"main"));
             break;
         default:
@@ -1799,8 +2391,8 @@ function setProtitlePosition(timepar,par,subfunc){
     switch(par){
         case "windowtopleft":
         case "headerleft":
-            headlogo.css("padding-top","18px")
-                .next().css("padding-top","18px")
+            headlogo.css("margin-top",(bigtext?10:6)+"px")
+                .next().css("margin-top",(bigtext?10:6)+"px")
             ;
 //console.log("windowTL.pad=18 setTitle("+(subfunc?"sub":"main"));
             break;
@@ -1809,7 +2401,12 @@ function setProtitlePosition(timepar,par,subfunc){
     switch(par){
         case "windowbottomright":
         case "footerright":
-            parexfootcount.css("padding-bottom","14px");
+            parexfootcount.css("margin-bottom",(bigtext?24:14)+"px")
+                .css("height","unset")
+            ;
+            $(EXfootcome).css("border-left","1px solid #444")
+                .prev().css("border-right","none")
+            ;
 //console.log("windowBR.pad=14 setTitle("+(subfunc?"sub":"main"));
             break;
         default:
@@ -1817,8 +2414,8 @@ function setProtitlePosition(timepar,par,subfunc){
     switch(par){
         case "windowbottomleft":
         case "footerleft":
-            footlogo.css("padding-bottom","14px")
-                .next().css("padding-bottom","14px")
+            footlogo.css("margin-bottom",(bigtext?24:14)+"px")
+                .next().css("margin-bottom",(bigtext?24:14)+"px")
             ;
 //console.log("windowBL.pad=14 setTitle("+(subfunc?"sub":"main"));
             break;
@@ -1829,47 +2426,55 @@ function setProtitlePosition(timepar,par,subfunc){
         case "windowtopright":
         case "windowbottomleft":
         case "windowbottomright":
-            tpro.prependTo('body');
+            if(!$('body').children().is(tpro)){
+                tpro.prependTo('body');
+            }
             break;
         case "commentinputtopleft":
         case "commentinputtopright":
         case "commentinputbottomleft":
         case "commentinputbottomright":
-            tpro.prependTo(EXcomesend);
+            if(!$(EXcomesend).children().is(tpro)){
+                tpro.prependTo(EXcomesend);
+            }
             break;
         case "headerleft":
         case "headerright":
-            tpro.prependTo(EXhead);
+            if(!$(EXhead).children().is(tpro)){
+                tpro.prependTo(EXhead);
+            }
             break;
         case "footerleft":
         case "footerright":
-            tpro.prependTo(EXfoot);
+            if(!$(EXfoot).children().is(tpro)){
+                tpro.prependTo(EXfoot);
+            }
             break;
         default:
     }
-    if(!subfunc){
-        proSamePositionFix(timepar,par);
-    }
 }
-function createTime(sw,posiset){
+function createTime(sw,bt){
 //console.log("createTime:"+sw);
     if(!EXcome){return;}
     if(sw==0){
+        var fsize=bt?"medium":"x-small";
         if($("#forProEndBk").length==0){
             var eForProEndBk = document.createElement("span");
             eForProEndBk.id="forProEndBk";
-            eForProEndBk.setAttribute("style","position:absolute;right:0;font-size:x-small;padding:0px 5px;background-color:rgba(255,255,255,0.2);z-index:18;width:310px;top:0px;");
+            eForProEndBk.setAttribute("style","position:absolute;right:0;font-size:"+fsize+";padding:0px 5px;background-color:rgba(255,255,255,0.2);z-index:18;width:310px;top:0px;");
             eForProEndBk.innerHTML="&nbsp;";
             EXcome.insertBefore(eForProEndBk,EXcome.firstChild);
         }
         if($("#forProEndTxt").length==0){
            var eForProEndTxt = document.createElement("span");
             eForProEndTxt.id="forProEndTxt";
-            eForProEndTxt.setAttribute("style","position:absolute;right:0;font-size:x-small;padding:0px 5px;color:rgba(255,255,255,0.8);text-align:right;letter-spacing:1px;z-index:19;width:310px;background-color:rgba(255,255,255,0.1);border-left:1px solid rgba(255,255,255,0.4);top:0px;");
+//            eForProEndTxt.setAttribute("style","position:absolute;right:0;font-size:x-small;padding:0px 5px;color:rgba(255,255,255,0.8);text-align:right;letter-spacing:1px;z-index:19;width:310px;background-color:rgba(255,255,255,0.1);border-left:1px solid rgba(255,255,255,0.4);top:0px;");
+            eForProEndTxt.setAttribute("style","position:absolute;right:0;font-size:"+fsize+";padding:0px 5px 0px 11px;color:rgba(255,255,255,0.8);text-align:right;letter-spacing:1px;z-index:19;background-color:transparent;top:0px;");
             eForProEndTxt.innerHTML="&nbsp;";
             EXcome.insertBefore(eForProEndTxt,EXcome.firstChild);
             //残り時間クリックで設定ウィンドウ開閉
-            $("#forProEndTxt").on("click",function(){
+            $("#forProEndTxt").prop("class","forProEndTxt")
+                .on("click",function(){
                if($("#settcont").css("display")=="none"){
                     openOption(isInpWinBottom?3:2);
                 }else{
@@ -1877,35 +2482,44 @@ function createTime(sw,posiset){
                 }
             });
         }
-        if(posiset){
-            setTimePosition();
+        if($("#proTimeEpNum").length==0){
+            var eproTimeEpNum = document.createElement("div");
+            eproTimeEpNum.id="proTimeEpNum";
+            eproTimeEpNum.setAttribute("style","position:absolute;right:0;font-size:x-small;padding:0px;background-color:transparent;z-index:17;width:310px;top:0px;text-align:center;color:rgba(255,255,255,0.3);display:flex;flex-direction:row;");
+            eproTimeEpNum.innerHTML='<div style="border-left:1px solid rgba(255,255,255,0.2);flex:1 0 1px;">&nbsp;</div><div style="border-left:1px solid rgba(255,255,255,0.2);flex:1 0 1px;">&nbsp;</div>';
+            EXcome.insertBefore(eproTimeEpNum,EXcome.firstChild);
         }
     }else if(sw==1){
         var prehoverContents = $('[class*="styles__hover-contents___"]').prev();
         var parexfootcount=$(EXfootcount).parent();
-        var forpros=$("#forProEndTxt,#forProEndBk");
+        var forpros=$("#forProEndTxt,#forProEndBk,#proTimeEpNum");
         prehoverContents.css("padding-top","")
             .prev().css("padding-top","")
         ;
         parexfootcount.css("padding-bottom","");
-        $(EXfootcome).next('#timerthird').remove();
-        $("#forProEndBk,#forProEndTxt").remove();
+//        $(EXfootcome).next('#timerthird').remove();
+        $("#forProEndBk,#forProEndTxt,#proTimeEpNum").remove();
     }
 }
-function setTimePosition(par,titlepar,subfunc){
+function setTimePosition(timepar,titlepar,samepar,bigpar){
 //console.log("setTimePosi par:"+par+", titlepar:"+titlepar+", sub:"+(subfunc?"true":"false"));
-    if(!subfunc){
-        proPositionAllReset();
-        setProtitlePosition(par,titlepar,true);
-    }
-    if(!par||par==""){par=($('#settcont').css("display")=="none")?timePosition:$('#itimePosition [name="timePosition"]:checked').val();}
-    if(!titlepar||titlepar==""){titlepar=($('#settcont').css("display")=="none")?protitlePosition:$('#iprotitlePosition [name="protitlePosition"]:checked').val();}
+//    if(!timepar||timepar==""){
+//        timepar=isTimeVisible?timePosition:"";
+//    }
+//    if(!titlepar||titlepar==""){
+//        titlepar=isProtitleVisible?protitlePosition:"";
+//    }
+//    if(!samepar||samepar==""){
+//        samepar=proSamePosition;
+//    }
 //    if(!par||par==""){par=timePosition;}
 //    if(!titlepar||titlepar==""){titlepar=protitlePosition;}
 //console.log("setTimePosi par:"+par+", titlepar:"+titlepar+", sub:"+(subfunc?"true":"false"));
     var prehoverContents = $('[class*="styles__hover-contents___"]').parent();
     var parexfootcount=$(EXfootcount).parent();
-    var forpros=$("#forProEndTxt,#forProEndBk");
+    var forpros=$("#forProEndTxt,#forProEndBk,#proTimeEpNum");
+    var bigtext=(bigpar!==undefined)?bigpar:isProTextLarge;
+    var par=timepar;
     switch(par){
         case "windowtop":
         case "commentinputtop":
@@ -1926,8 +2540,8 @@ function setTimePosition(par,titlepar,subfunc){
     switch(par){
         case "windowtop":
         case "header":
-            prehoverContents.css("padding-top","9px")
-                .prev().css("padding-top","9px")
+            prehoverContents.css("margin-top",(bigtext?14:9)+"px")
+                .prev().css("margin-top",(bigtext?14:9)+"px")
             ;
 //console.log("windowTR.pad=9 setTime("+(subfunc?"sub":"main"));
             break;
@@ -1936,52 +2550,62 @@ function setTimePosition(par,titlepar,subfunc){
     switch(par){
         case "windowbottom":
         case "footer":
-            parexfootcount.css("padding-bottom","14px");
+            parexfootcount.css("margin-bottom",(bigtext?24:14)+"px")
+                .css("height","unset")
+            ;
+            $(EXfootcome).css("border-left","1px solid #444")
+                .prev().css("border-right","none")
+            ;
 //console.log("windowBR.pad=14 setTime("+(subfunc?"sub":"main"));
-            if($(EXfootcome).next('#timerthird').length==0){
-                $('<div id="timerthird" style="position:absolute;bottom:0;right:207px;height:15px;width:143px;color:white;font-size:x-small;letter-spacing:1px;padding:0px 5px;border-right:1px solid #444;"></div>').insertAfter(EXfootcome);
-                $(EXfootcome).next('#timerthird').html('&nbsp;');
-            }
+//            if($(EXfootcome).next('#timerthird').length==0){
+//                $('<div id="timerthird" style="position:absolute;bottom:0;right:207px;height:15px;width:143px;color:white;font-size:x-small;letter-spacing:1px;padding:0px 5px;border-right:1px solid #444;"></div>').insertAfter(EXfootcome);
+//                $(EXfootcome).next('#timerthird').html('&nbsp;');
+//            }
             break;
         default:
     }
     switch(par){
         case "windowtop":
         case "windowbottom":
-            forpros.prependTo('body');
+            if(!$('body').children().is(forpros)){
+                forpros.prependTo('body');
+            }
             break;
         case "commentinputtop":
         case "commentinputbottom":
-            forpros.prependTo(EXcomesend);
+            if(!$(EXcomesend).children().is(forpros)){
+                forpros.prependTo(EXcomesend);
+            }
             break;
         case "header":
-            forpros.prependTo(EXhead);
+            if(!$(EXhead).children().is(forpros)){
+                forpros.prependTo(EXhead);
+            }
         case "footer":
-            forpros.prependTo(EXfoot);
+            if(!$(EXfoot).children().is(forpros)){
+                forpros.prependTo(EXfoot);
+            }
         default:
     }
-    if(!subfunc){
-        proSamePositionFix(par,titlepar);
-    }
 }
-function waitforpop(retrycount){
-    if($(EXhead).css("visibility")=="visible"){
-//console.log("comevisiset waitforhide");
-        comevisiset(false);
-    }else if(retrycount>0){
-        setTimeout(waitforpop,100,retrycount-1);
-    }
-}
-function waitforhide(retrycount){
-    if($(EXhead).css("visibility")=="hidden"){
-//console.log("comevisiset waitforhide");
-        comevisiset(false);
-    }else if(retrycount>0){
-        setTimeout(waitforhide,100,retrycount-1);
-    }
-}
+//function waitforpop(retrycount){
+//    if($(EXhead).css("visibility")=="visible"){
+////console.log("comevisiset waitforhide");
+//        comevisiset(false);
+//    }else if(retrycount>0){
+//        setTimeout(waitforpop,100,retrycount-1);
+//    }
+//}
+//function waitforhide(retrycount){
+//    if($(EXhead).css("visibility")=="hidden"){
+////console.log("comevisiset waitforhide");
+//        comevisiset(false);
+//    }else if(retrycount>0){
+//        setTimeout(waitforhide,100,retrycount-1);
+//    }
+//}
 function setOptionHead(){
-    $('head:first>link[title="usermade"]').remove();
+    $('head>link[title="usermade"]').remove();
     var t="";
     //コメントのZ位置を上へ
     if(isMovingComment){
@@ -1989,7 +2613,8 @@ function setOptionHead(){
     }
     //投稿ボタン削除（入力欄1行化はこの下のコメ見た目のほうとoptionElementでやる）
     if(isCustomPostWin){
-        t+='[class^="styles__opened-textarea-wrapper___"]+div{display:none;}';
+//        t+='[class^="styles__opened-textarea-wrapper___"]+div{display:none;}';
+        t+='[class^="TVContainer__right-comment-area___"] [class*="styles__comment-form___"]>[class*="styles__etc-modules___"]{display:none;}';
     }
     //コメント見た目
     var bc="rgba("+commentBackColor+","+commentBackColor+","+commentBackColor+","+(commentBackTrans/255)+")";
@@ -2001,24 +2626,9 @@ function setOptionHead(){
     t+='[class^="TVContainer__right-comment-area___"]>*{background-color:transparent;}';
     t+='[class^="TVContainer__right-comment-area___"] [class*="styles__comment-form___"]{background-color:'+bc+';}';
     t+='[class^="TVContainer__right-comment-area___"] [class^="styles__opened-textarea-wrapper___"]{background-color:'+uc+';}';
-    t+='[class^="TVContainer__right-comment-area___"] textarea{background-color:'+uc+';color:'+tc+';';
-    if(isCustomPostWin){
-        t+='height:18px!important;';
-    }
-    t+='}';
-    t+='[class^="TVContainer__right-comment-area___"] textarea+*{background-color:'+cc+';color:'+tc+';';
-    if(isCustomPostWin){
-        t+='height:18px!important;';
-    }
-    t+='}';
-    t+='[class^="TVContainer__right-comment-area___"] [class^="styles__comment-list-wrapper___"]>div>div{background-color:'+bc+';color:'+tc+';';
-    if(isCommentPadZero){
-        t+='padding:0px 15px;';
-    }
-    if(isCommentTBorder){
-        t+='border-top:1px solid '+vc+';';
-    }
-    t+='}';
+    t+='[class^="TVContainer__right-comment-area___"] textarea{background-color:'+uc+';color:'+tc+';}';
+    t+='[class^="TVContainer__right-comment-area___"] textarea+*{background-color:'+cc+';color:'+tc+';}';
+    t+='[class^="TVContainer__right-comment-area___"] [class^="styles__comment-list-wrapper___"]>div>div{background-color:'+bc+';color:'+tc+';}';
     t+='[class^="TVContainer__right-comment-area___"] [class^="styles__comment-list-wrapper___"]>div>div>p[class^="styles__message__"]{color:'+tc+';}';
     //映像最大化
     if(isMovieMaximize||isSureReadComment){
@@ -2036,12 +2646,14 @@ function setOptionHead(){
         t+='}';
     }
 
-    t+='[class^="TVContainer__right-comment-area___"] [class^="styles__comment-list-wrapper___"]>div{';
-    if(isInpWinBottom){
-        //コメ逆順
-        t+='display:flex;flex-direction:column-reverse;';
-    }
     //コメ欄スクロールバー非表示
+    if(isInpWinBottom){//コメ逆順の時は対象が逆になる
+        t+='[class^="TVContainer__right-comment-area___"] [class^="styles__comment-list-wrapper___"]{overflow:hidden;}';
+        t+='[class^="TVContainer__right-comment-area___"] [class^="styles__comment-list-wrapper___"]>div{';
+    }else{
+        t+='[class^="TVContainer__right-comment-area___"] [class^="styles__comment-list-wrapper___"]>div{overflow:hidden;}';
+        t+='[class^="TVContainer__right-comment-area___"] [class^="styles__comment-list-wrapper___"]{';
+    }
     if(isHideOldComment){
         t+='overflow:hidden;';
     }else{
@@ -2050,18 +2662,43 @@ function setOptionHead(){
     t+='}';
     //ユーザースクリプトのngconfigのz-index変更
     t+='#NGConfig{z-index:20;}';
-    //黒帯パネルを常に表示
-    if(settings.isAlwaysShowPanel){
-        t+='[class^="AppContainer__header-container___"]{visibility:visible;opacity:1;}';
-        t+='[class^="TVContainer__footer-container___"]{visibility:visible;opacity:1;}';
-        t+='[class^="TVContainer__side___"]{transform:translate(0px, -50%);}';
-    }
     //コメント欄を常に表示
     if(isSureReadComment){
-        t+='[class^="TVContainer__right-comment-area___"]{transform:translateX(0);}';
+//        t+='[class^="TVContainer__right-comment-area___"]{transform:translateX(0);}';
         t+='[class^="TVContainer__right-list-slide___"]{z-index:11;}'; //コメ欄は10
         t+='[class^="TVContainer__right-slide___"]{z-index:11;}';
     }
+    if(isInpWinBottom){ //コメ入力欄を下
+        t+='[class^="TVContainer__right-comment-area___"]>*{display:flex;flex-direction:column-reverse;}';
+        t+='[class^="TVContainer__right-comment-area___"] [class^="styles__comment-list-wrapper___"]{display:flex;flex-direction:column;justify-content:flex-end;border-top:1px solid '+vc+';border-bottom:1px solid '+vc+';}';
+        t+='[class^="TVContainer__right-comment-area___"] [class^="styles__comment-list-wrapper___"]>div{display:flex;flex-direction:column-reverse;}';
+    }
+    if(isCustomPostWin){ //1行化
+        t+='[class^="TVContainer__right-comment-area___"] textarea{height:18px!important;}';
+        t+='[class^="TVContainer__right-comment-area___"] textarea+*{height:18px!important;}';
+    }
+    if(isCommentPadZero){ //コメ間隔詰め
+        t+='[class^="TVContainer__right-comment-area___"] [class^="styles__comment-list-wrapper___"]>div>div{padding-top:0px;padding-bottom:0px;}';
+    }
+    if(isCommentTBorder){ //コメ区切り線
+        t+='[class^="TVContainer__right-comment-area___"] [class^="styles__comment-list-wrapper___"]>div>div{border-top:1px solid '+vc+';}';
+        if(isInpWinBottom){ //先頭コメ(一番下)の下にも線を引く
+            t+='[class^="TVContainer__right-comment-area___"] [class^="styles__comment-list-wrapper___"]>div>div:first{border-bottom:1px solid '+vc+';}';
+        }
+    }
+    if(isCommentWide){ //コメント部分をほんの少し広く
+        t+='[class^="TVContainer__right-comment-area___"] [class^="styles__comment-list-wrapper___"]>div>div{padding-right:4px;padding-left:8px;}';
+        t+='[class^="TVContainer__right-comment-area___"] [class^="styles__comment-list-wrapper___"]>div>div>p[class^="styles__message__"]{width:'+(isHideOldComment?260:244)+'px;}';
+    }
+    //各パネルの常時表示 隠す場合は積極的にelement.cssに隠す旨を記述する(fade-out等に任せたり単にcss除去で済まさない)
+    //もしくは常時隠して表示する場合に記述する、つまり表示切替の一切を自力でやる
+    //（コメ欄常時表示で黒帯パネルの表示切替が発生した時のレイアウト崩れを防ぐため）
+    t+='[class^="AppContainer__header-container___"]{visibility:visible;opacity:1;}';
+    t+='[class^="TVContainer__footer-container___"]{visibility:visible;opacity:1;}';
+    t+='[class^="TVContainer__side___"]{transform:translateY(-50%);}';
+//    t+='[class^="TVContainer__right-list-slide___"]{transform:translateX(0);}';
+//    t+='[class^="TVContainer__right-slide___"]{transform:translateX(0);}';
+
     $("<link title='usermade' rel='stylesheet' href='data:text/css," + encodeURI(t) + "'>").appendTo("head");
 console.log("setOptionHead ok");
 }
@@ -2076,32 +2713,29 @@ console.log("setOptionElement retry");
     }else{
         $(EXcomesendinp).prop("wrap","");
     }
-    if(isTimeVisible){
-        createTime(0,false);
-        setTimePosition();
-    }else{
-        createTime(1);
-    }
-    if(isProtitleVisible){
-        createProtitle(0,false);
-        setProtitlePosition();
-    }else{
-        createProtitle(1);
-    }
+    setProSamePosiChanged();
     $(EXfootcome).css("pointer-events","auto");
 console.log("setOptionElement ok");
 }
 function usereventMouseover(){
-    if(isOpenPanelwCome&&!settings.isAlwaysShowPanel&&isComeOpen()){
-        //各要素を隠すまでのカウントをマウスオーバーで5にリセット
+    //マウスオーバーで表示させる場合はカウントリセット
+    if(!settings.isAlwaysShowPanel&&(!isComeOpen()||isOpenPanelwCome)){
         if(forElementClose<4){
             forElementClose=5;
 console.log("popElement usereventMouseover");
-            popElement(); //各要素を表示
+            popElement({head:true,foot:true,side:true});
         }
-    }else if(popElemented){
-        unpopElement(); //popElementの設定を消す
     }
+//    if(isOpenPanelwCome&&!settings.isAlwaysShowPanel&&isComeOpen()){
+//        //各要素を隠すまでのカウントをマウスオーバーで5にリセット
+//        if(forElementClose<4){
+//            forElementClose=5;
+//console.log("popElement usereventMouseover");
+//            popElement(); //各要素を表示
+//        }
+//    }else if(popElemented){
+//        unpopElement(); //popElementの設定を消す
+//    }
 }
 function usereventWakuclick(){
 //console.log("wakuclick");
@@ -2127,7 +2761,7 @@ function usereventFCMouseleave(){
         .css("background-color","")
     ;
 //    $('body:first>#manualblockrd').remove();
-    $('body:first>.manualblock').remove();
+    $('.manualblock').remove();
 //    if($('body:first>.manualblock').length==0){
     $('body').css("overflow-y","");
 //    }
@@ -2150,10 +2784,10 @@ function finishFCbgColored(){
     $(EXfootcome).css("transition","")
         .css("background-color","")
     ;
-    if($('body:first>#manualblockrd').length==0){
+    if($('#manualblockrd').length==0){
         $('body').css("overflow-y","hidden");
         $('<div id="manualblockrd" class="manualblock"></div>').appendTo('body');
-        $('body:first>#manualblockrd').html('&nbsp;')
+        $('#manualblockrd').html('&nbsp;')
             .css("position","absolute")
             .css("height","5px")
             .css("width","5px")
@@ -2207,7 +2841,7 @@ function setOptionEvent(){
     if(eventAdded){return;}
     var butfs;
     var pwaku;
-    if(((butfs=$('button[class*="styles__full-screen___"]:first')[0])==null)||((pwaku=$('[class^="style__overlap___"]:first')[0])==null)||!EXcome){
+    if(((butfs=$('button[class*="styles__full-screen___"]')[0])==null)||((pwaku=$('[class^="style__overlap___"]')[0])==null)||!EXcome){
 console.log("setOptionEvent retry");
         setTimeout(setOptionEvent,1000);
         return;
@@ -2222,7 +2856,6 @@ console.log("dblclick");
     });
     //コメ常時表示のときは画面クリックした後に開こうとする
     $(window).on("click",function(){
-//console.log("windowclick");
         if(isSureReadComment){
             comeclickcd=2;
         }
@@ -2233,7 +2866,7 @@ console.log("dblclick");
     //マウスホイール無効か音量操作
     window.addEventListener("mousewheel",function(e){
         if (isVolumeWheel&&e.target.className.indexOf("style__overlap___") != -1){//イベントが映像上なら
-            if(EXvolume&&$(EXvolume).contents().find('svg:first').css("zoom")=="1"){
+            if(EXvolume&&$(EXvolume).contents().find('svg').css("zoom")=="1"){
                 otoSize(e.wheelDelta<0?0.8:1.2);
             }
             moVol(e.wheelDelta<0?-5:5);
@@ -2255,6 +2888,8 @@ console.log("dblclick");
         if(isComeOpen()){
 //console.log("toggleCommentList EXfootcomeclick");
             toggleCommentList();
+        }else if(!settings.isAlwaysShowPanel&&!isOpenPanelwCome){
+            hideElement({head:true,foot:true,side:true});
         }
     });
     //コメント一覧の表示切替
@@ -2292,10 +2927,10 @@ console.log("dblclick");
                 }else if(e.location==2&&isManualKeyCtrlR){
                     posi="right";
                 }
-                if(posi!=""&&$('body:first>#manualblock'+posi).length==0){
+                if(posi!=""&&$('#manualblock'+posi).length==0){
                     $('body').css("overflow-y","hidden");
                     $('<div id="manualblock'+posi+'" class="manualblock"></div>').appendTo('body');
-                    $('body:first>#manualblock'+posi).html('&nbsp;')
+                    $('#manualblock'+posi).html('&nbsp;')
                         .css("position","absolute")
                         .css("height","5px")
                         .css("width","5px")
@@ -2340,7 +2975,7 @@ console.log("dblclick");
 //                posi="right";
 //            }
 //            $('body:first>#manualblock'+posi).remove();
-            $('body:first>.manualblock').remove();
+            $('.manualblock').remove();
 //            if($('body:first>.manualblock').length==0){
             $('body').css("overflow-y","");
 //            }
@@ -2367,9 +3002,9 @@ console.log("endCM");
 function tryCM(){
     if(bginfo[1].length!=0){return;}
     bginfo[2]=0;
-    if(EXfootcome&&$(EXfootcome).next('#timerthird').length>0&&bginfo[0]>0){
-        $(EXfootcome).next('#timerthird').html('&nbsp;');
-    }
+//    if(EXfootcome&&$(EXfootcome).next('#timerthird').length>0&&bginfo[0]>0){
+//        $(EXfootcome).next('#timerthird').html('&nbsp;');
+//    }
     if(cmblockcd*100%10!=-3){
         cmblockcd=0;
         endCM();
@@ -2392,26 +3027,28 @@ $(window).on('load', function () {
 
     setInterval(function () {
         // 1秒ごとに実行
-        var btn = $('[class^="TVContainer__right-comment-area___"] [class^="styles__continue-btn___"]'); //新着コメのボタン
-        if (btn.length>0) {
-            //var newCommentNum = parseInt(btn.text().match("^[0-9]+"));
-            btn.trigger("click");// 1秒毎にコメントの読み込みボタンを自動クリック
+        if(EXcome){
+            var btn = $(EXcome).contents().find('[class^="styles__continue-btn___"]'); //新着コメのボタン
+            if (btn.length>0) {
+                //var newCommentNum = parseInt(btn.text().match("^[0-9]+"));
+                btn.trigger("click");// 1秒毎にコメントの読み込みボタンを自動クリック
+            }
         }
         //映像のtopが変更したらonresize()実行
         if(settings.isResizeScreen && $("object").parent().offset().top !== newtop) {
             onresize();
         }
-        //黒帯パネル表示のためマウスを動かすイベント発火
-        if (settings.isAlwaysShowPanel) {
-            triggerMouseMoving();
-            if(!isSureReadComment){
+//        //黒帯パネル表示のためマウスを動かすイベント発火
+//        if (settings.isAlwaysShowPanel) {
+//            triggerMouseMoving();
+//            if(!isSureReadComment){
 //console.log("popHeader 1s");
 //                popHeader();
-            }
-        }
+//            }
+//        }
         //音量が最大なら設定値へ自動変更
         if(changeMaxVolume<100&&$('[class^="styles__highlighter___"]').css("height")=="92px"){
-            if($(EXvolume).contents().find('svg:first').css("fill")=="rgb(255, 255, 255)"){
+            if($(EXvolume).contents().find('svg').css("fill")=="rgb(255, 255, 255)"){
                 otoColor();
             }
             otosageru();
@@ -2440,11 +3077,12 @@ $(window).on('load', function () {
                     comeColor(comeHealth);
                 }
                 commentNum=comeListLen;
-                if(isSureReadComment&&commentNum>Math.max(comeHealth+20,sureReadRefreshx)&&$(EXfootcome).filter('[class*="styles__right-container-not-clickable___"]').length==0&&$(EXcome).siblings('[class*="TVContainer__right-slide--shown___"]').length==0){
+//                if(isSureReadComment&&commentNum>Math.max(comeHealth+20,sureReadRefreshx)&&$(EXfootcome).filter('[class*="styles__right-container-not-clickable___"]').length==0&&$(EXcome).siblings('[class*="TVContainer__right-slide--shown___"]').length==0){
+                if(isSureReadComment&&commentNum>Math.max(comeHealth+20,sureReadRefreshx)&&!$(EXfootcome).is('[class*="styles__right-container-not-clickable___"]')&&$(EXcome).siblings('[class*="TVContainer__right-slide--shown___"]').length==0){
                     //コメ常時表示 & コメ数>設定値 & コメ開可 & 他枠非表示
                     comeRefreshing=true;
 //                    commentNum=0;
-                    $('[class^="style__overlap___"]:first').trigger("click");
+                    $('[class^="style__overlap___"]').trigger("click");
                     fastRefreshing();
                 }
             }else if(comeListLen<commentNum){
@@ -2457,7 +3095,7 @@ $(window).on('load', function () {
 //        var arMovingComment = $('[class="movingComment"]');
 //        if(arMovingComment.length>0){
         if(isMovingComment){
-            var arMovingComment = $('body:first>#moveContainer>.movingComment');
+            var arMovingComment = $('.movingComment');
             for (var j = arMovingComment.length-1;j>=0;j--){
                 if(arMovingComment.eq(j).offset().left + arMovingComment.eq(j).width()<=0){
                     arMovingComment[j].remove();
@@ -2479,52 +3117,81 @@ $(window).on('load', function () {
 //            }
 //        }
 
-        var countElements = $('[class^="TVContainer__footer___"] [class*="styles__count___"]');
+//        var countElements = $('[class^="TVContainer__footer___"] [class*="styles__count___"]');
         //var viewCount = countElements[0].innerHTML
         //var commentCount = countElements[1].innerHTML
-        //コメント数無効の時画面真っ黒
-        var faintchecked=false;
-        if (isCMBlack) {
-            var pwaku = $('[class^="style__overlap___"]'); //動画枠
-            var come = $('[class*="styles__counter___"]'); //画面右下のカウンター
-            if(pwaku[0]&&come[1]){
-                //切替時のみ動作
-                if(isNaN(parseInt(come[1].innerHTML))&&comeLatestCount>=0){
-                    //今コメント数無効で直前がコメント数有効(=コメント数無効開始?)
-                    if(cmblockcd<=0){
-                      cmblockcd=cmblockia;
-                    }
-                }else if(!isNaN(parseInt(come[1].innerHTML))&&comeLatestCount<0){
-                    //今コメント数有効で直前がコメント数無効(=コメント数無効終了?)
-                    if(!faintchecked){
-                      faintchecked=true;
-                      faintcheck(cmblockcd);
-                    }
-                    cmblockcd=cmblockib;
-                }
-            }
-        }
 
-        //コメント数無効の時音量ミュート
-        if (isCMsoundoff){
-            var valvol=$('[class^="styles__volume___"] [class^="styles__highlighter___"]'); //高さが音量のやつ
-            var come = $('[class*="styles__counter___"]'); //画面右下のカウンター
-            if (valvol[0]&&come[1]){
-                if(isNaN(parseInt(come[1].innerHTML))&&comeLatestCount>=0){
+        //2つに分かれていたのを統合
+        //この後ろで結局コメ数チェックするのでここでついでに実行
+        if(EXfootcountcome){
+            var comeContStr=EXfootcountcome.innerHTML;
+            var commentCount;
+            if(isNaN(parseInt(comeContStr))){ //今コメント無効
+                commentCount=-1;
+            }else{
+                commentCount=parseInt(comeContStr);
+            }
+            if(isCMBlack||isCMsoundoff||CMsmall<100){
+                if(commentCount<0&&comeLatestCount>=0){
                     //今コメント数無効で直前がコメント数有効(=コメント数無効開始?)
                     if(cmblockcd<=0){
-                      cmblockcd=cmblockia;
+                        faintcheck(cmblockcd,1);
+                        cmblockcd=cmblockia;
                     }
-                }else if(!isNaN(parseInt(come[1].innerHTML))&&comeLatestCount<0){
+                }else if(commentCount>=0&&comeLatestCount<0){
                     //今コメント数有効で直前がコメント数無効(=コメント数無効終了?)
-                    if(!faintchecked){
-                      faintchecked=true;
-                      faintcheck(cmblockcd);
+                    if(cmblockcd>=0){
+                        faintcheck(cmblockcd,-1);
+                        cmblockcd=cmblockib;
                     }
-                    cmblockcd=cmblockib;
                 }
+            }else{
             }
+            comeLatestCount=commentCount;
         }
+//        //コメント数無効の時画面真っ黒
+//        var faintchecked=false;
+//        if (isCMBlack) {
+//            var pwaku = $('[class^="style__overlap___"]'); //動画枠
+//            var come = $('[class*="styles__counter___"]'); //画面右下のカウンター
+//            if(pwaku[0]&&come[1]){
+//                //切替時のみ動作
+//                if(isNaN(parseInt(come[1].innerHTML))&&comeLatestCount>=0){
+//                    //今コメント数無効で直前がコメント数有効(=コメント数無効開始?)
+//                    if(cmblockcd<=0){
+//                      cmblockcd=cmblockia;
+//                    }
+//                }else if(!isNaN(parseInt(come[1].innerHTML))&&comeLatestCount<0){
+//                    //今コメント数有効で直前がコメント数無効(=コメント数無効終了?)
+//                    if(!faintchecked){
+//                      faintchecked=true;
+//                      faintcheck(cmblockcd);
+//                    }
+//                    cmblockcd=cmblockib;
+//                }
+//            }
+//        }
+//
+//        //コメント数無効の時音量ミュート
+//        if (isCMsoundoff){
+//            var valvol=$('[class^="styles__volume___"] [class^="styles__highlighter___"]'); //高さが音量のやつ
+//            var come = $('[class*="styles__counter___"]'); //画面右下のカウンター
+//            if (valvol[0]&&come[1]){
+//                if(isNaN(parseInt(come[1].innerHTML))&&comeLatestCount>=0){
+//                    //今コメント数無効で直前がコメント数有効(=コメント数無効開始?)
+//                    if(cmblockcd<=0){
+//                      cmblockcd=cmblockia;
+//                    }
+//                }else if(!isNaN(parseInt(come[1].innerHTML))&&comeLatestCount<0){
+//                    //今コメント数有効で直前がコメント数無効(=コメント数無効終了?)
+//                    if(!faintchecked){
+//                      faintchecked=true;
+//                      faintcheck(cmblockcd);
+//                    }
+//                    cmblockcd=cmblockib;
+//                }
+//            }
+//        }
         if(cmblockcd!=0){
             if(cmblockcd>0){
                 cmblockcd-=1;
@@ -2553,11 +3220,11 @@ $(window).on('load', function () {
 //        }else{
 //            comeLatestCount=-1;
 //        }
-        if(isNaN(parseInt($(EXfootcountcome).text()))){
-            comeLatestCount=-1;
-        }else{
-            comeLatestCount=parseInt($(EXfootcountcome).text());
-        }
+//        if(isNaN(parseInt($(EXfootcountcome).text()))){
+//            comeLatestCount=-1;
+//        }else{
+//            comeLatestCount=parseInt($(EXfootcountcome).text());
+//        }
 
         //残り時間表示
         if (isTimeVisible&&EXinfo){
@@ -2609,10 +3276,13 @@ $(window).on('load', function () {
             var proLength = proEnd.getTime() - proStart.getTime(); //番組の全体長さ
             var strProEnd = Math.floor(forProEnd/1000);
             if(forProEnd>0){
-                strProEnd = (("0"+Math.floor(forProEnd/3600000)).slice(-2)+" : "+("0"+Math.floor((forProEnd%3600000)/60000)).slice(-2)+" : "+("0"+Math.floor((forProEnd%60000)/1000)).slice(-2)).replace(/^00?( : )?0?0?( : )?0?/,"");
+//                strProEnd = (("0"+Math.floor(forProEnd/3600000)).slice(-2)+" : "+("0"+Math.floor((forProEnd%3600000)/60000)).slice(-2)+" : "+("0"+Math.floor((forProEnd%60000)/1000)).slice(-2)).replace(/^00?( : )?0?0?( : )?0?/,"");
+                strProEnd = (("0"+Math.floor(forProEnd/3600000)).slice(-2)+"："+("0"+Math.floor((forProEnd%3600000)/60000)).slice(-2)+"："+("0"+Math.floor((forProEnd%60000)/1000)).slice(-2)).replace(/^[0：]*/,"");
             }
-            $("#forProEndTxt").text(strProEnd);
-            $("#forProEndBk").css("width",((forProEnd>0)?Math.floor(310*forProEnd/proLength):310)+"px");
+            if($("#forProEndTxt").filter(".forProEndTxt").length>0){
+                $("#forProEndTxt").filter(".forProEndTxt").text(strProEnd);
+                $("#forProEndBk").css("width",((forProEnd>0)?Math.floor(310*forProEnd/proLength):310)+"px");
+            }
         }
         //コメント欄を常時表示
         if(isSureReadComment){
@@ -2630,8 +3300,9 @@ $(window).on('load', function () {
         if(forElementClose>0){
             forElementClose-=1;
             if(forElementClose<=0){
-                //各要素を隠す
-                unpopElement();
+                //黒パネルを隠す
+                hideElement({head:true,foot:true,side:true});
+//                unpopElement();
 //                $(EXside).css("transform","");
 //                $(EXhead).css("visibility","")
 //                  .css("opacity","")
@@ -2657,21 +3328,28 @@ $(window).on('load', function () {
             }
         }
 
-        //一時設定画面の情報更新
-        if($('body:first>#settcont').css("display")!="none"){
-            optionStatsUpdate(false);
-        }
+//一時設定画面を開いた時に定期実行を開始するように変更
+//        //一時設定画面の情報更新
+//        if($('body:first>#settcont').css("display")!="none"){
+//            optionStatsUpdate(false);
+//        }
         //番組タイトルの更新
         if(isProtitleVisible&&EXinfo){
             var jo=$(EXinfo).contents().find('h2');
             if(jo.length>0){
-                proTitle=jo.first().text();
-                $('#tProtitle').text(proTitle);
+                if($('#tProtitle').text()!=jo.first().text()){
+                    proTitle=jo.first().text();
+                    $('#tProtitle').text(proTitle);
+                }
             }
         }
-
 //console.log(ttlmonitora);
 //console.log(ttlmonitorb);
+
+//無変化時のカラ実行を防ぐため、黒パネルの表示切替は全て自力で行う
+//        //コメ欄表示調整（黒帯が自動で閉じた時に崩れるのを直す）
+//        setTimeout(comevisiset,500,false);
+
 
     }, 1000);
 
@@ -2699,6 +3377,9 @@ function chkurl() {
         bginfo=[0,[],-1,-1];
         endCM();
         checkUrlPattern(currentLocation);
+        proStart=new Date();
+        proEnd=new Date();
+        proTitle="未取得";
     }
 }
 //onloadからも呼ばれる
@@ -2791,14 +3472,14 @@ chrome.runtime.onMessage.addListener(function(r){
             if(bginfo[1].length>0&&bginfo[1][2]-bginfo[1][1]>5){
 //console.log("bginfo[2]= "+bginfo[2]+" -> 3");
                 bginfo[2]=3;
-                if(EXfootcome&&$(EXfootcome).next('#timerthird').length>0){
-                    $(EXfootcome).next('#timerthird').text('CM>');
-                }
+//                if(EXfootcome&&$(EXfootcome).next('#timerthird').length>0){
+//                    $(EXfootcome).next('#timerthird').text('CM>');
+//                }
             }
         }else{
-            if(EXfootcome&&$(EXfootcome).next('#timerthird').length>0&&bginfo[0]>0){
-                $(EXfootcome).next('#timerthird').html('&nbsp;');
-            }
+//            if(EXfootcome&&$(EXfootcome).next('#timerthird').length>0&&bginfo[0]>0){
+//                $(EXfootcome).next('#timerthird').html('&nbsp;');
+//            }
         }
     }else if(r.type==1){
 //console.log("nowcm#"+r.value[0]+","+r.value[1]+"/"+r.value[2]);
@@ -2819,9 +3500,9 @@ chrome.runtime.onMessage.addListener(function(r){
             if(bginfo[2]<=1){
 //console.log("bginfo[2]= "+bginfo[2]+" -> 2");
                 bginfo[2]=2;
-                if(EXfootcome&&$(EXfootcome).next('#timerthird').length>0){
-                    $(EXfootcome).next('#timerthird').text('CM');
-                }
+//                if(EXfootcome&&$(EXfootcome).next('#timerthird').length>0){
+//                    $(EXfootcome).next('#timerthird').text('CM');
+//                }
                 if(cmblockcd*100%10!=3){
                     cmblockcd=0;
                     startCM();
@@ -2835,9 +3516,9 @@ chrome.runtime.onMessage.addListener(function(r){
                 if(bginfo[2]==3){
 //console.log("bginfo[2]= 3 -> 0");
                     bginfo[2]=0;
-                    if(EXfootcome&&$(EXfootcome).next('#timerthird').length>0&&bginfo[0]>0){
-                        $(EXfootcome).next('#timerthird').html('&nbsp;');
-                    }
+//                    if(EXfootcome&&$(EXfootcome).next('#timerthird').length>0&&bginfo[0]>0){
+//                        $(EXfootcome).next('#timerthird').html('&nbsp;');
+//                    }
                     if(cmblockcd*100%10!=-3){
                         cmblockcd=0;
                         endCM();
@@ -2853,9 +3534,9 @@ chrome.runtime.onMessage.addListener(function(r){
         if(bginfo[1].length==0){
 //console.log("bginfo[2]= "+bginfo[2]+" -> 1");
             bginfo[2]=1;
-            if(EXfootcome&&$(EXfootcome).next('#timerthird').length>0){
-                $(EXfootcome).next('#timerthird').text('>CM');
-            }
+//            if(EXfootcome&&$(EXfootcome).next('#timerthird').length>0){
+//                $(EXfootcome).next('#timerthird').text('>CM');
+//            }
         }
     }
 });

--- a/option.js
+++ b/option.js
@@ -89,6 +89,8 @@ $(function(){
         var isProtitleVisible=value.protitleVisible||false;
         var protitlePosition=value.protitlePosition||"windowtopleft";
         var proSamePosition=value.proSamePosition||"over";
+        var isProTextLarge=value.proTextLarge||false;
+        var isCommentWide=value.commentWide||false;
         $("#isResizeScreen").prop("checked", isResizeScreen);
         $("#isDblFullscreen").prop("checked", isDblFullscreen);
         $("#isEnterSubmit").prop("checked", isEnterSubmit);
@@ -151,6 +153,8 @@ $(function(){
         $("#isProtitleVisible").prop("checked",isProtitleVisible);
         $('#iprotitlePosition [type="radio"][name="protitlePosition"]').val([protitlePosition]);
         $('#iproSamePosition [type="radio"][name="proSamePosition"]').val([proSamePosition]);
+        $('#isProTextLarge').prop("checked",isProTextLarge);
+        $('#isCommentWide').prop("checked",isCommentWide);
     });
     if($('#settingsArea #CommentMukouSettings .setTables').length==0){
         $('#settingsArea #CommentMukouSettings').wrapInner('<div id="ComeMukouD">');
@@ -280,7 +284,9 @@ $(function(){
             "openPanelwCome":$("#isOpenPanelwCome").prop("checked"),
             "protitleVisible":$("#isProtitleVisible").prop("checked"),
             "protitlePosition":$('#iprotitlePosition [name="protitlePosition"]:checked').val(),
-            "proSamePosition":$('#iproSamePosition [name="proSamePosition"]:checked').val()
+            "proSamePosition":$('#iproSamePosition [name="proSamePosition"]:checked').val(),
+            "proTextLarge":$('#isProTextLarge').prop("checked"),
+            "commentWide":$('#isCommentWide').prop("checked")
         }, function () {
             $("#info").show().text("設定保存しました").fadeOut(4000);
         });

--- a/settings.js
+++ b/settings.js
@@ -120,8 +120,15 @@ var settingsList = [
         "isInstantChangable": true
     },
     {
+        "name": "isProTextLarge",
+        "description": "番組残り時間・タイトルの文字を大きくする",
+        "type": "boolean",
+        "isInstantChangable": true
+    },
+    {
         "name": "isSureReadComment",
-        "description": "常にコメント欄を表示する",
+//        "description": "常にコメント欄を表示する",
+        "description": "常にコメント欄を表示しようとする",
         "type": "boolean",
 //        "isInstantChangable": false
         "isInstantChangable": true
@@ -139,6 +146,13 @@ var settingsList = [
         "description": "常に黒帯パネルを表示する",
         "type": "boolean",
 //        "isInstantChangable": false
+        "isInstantChangable": true
+    },
+    {
+        "name": "isOpenPanelwCome",
+//        "description": "コメント欄を開いていても黒帯パネルを表示する",
+        "description": "コメント欄を開いていても黒帯パネル等を表示できるようにする",
+        "type": "boolean",
         "isInstantChangable": true
     },
     {
@@ -163,6 +177,12 @@ var settingsList = [
         "isInstantChangable": true
     },
     {
+        "name": "isCommentWide",
+        "description": "コメントを横にほんの少し広げる",
+        "type": "boolean",
+        "isInstantChangable": true
+    },
+    {
         "name": "notifySeconds",
         "description": "番組通知を番組開始の何秒前にするか(番組表の番組ページから番組開始前の通知を設定できます。)",
         "type": "number",
@@ -179,12 +199,6 @@ var settingsList = [
         "description": "↑既に開いている放送画面があれば新しいタブを開かずそのタブを切り替える(アクティブなタブ優先)",
         "type": "boolean",
         "isInstantChangable": false
-    },
-    {
-        "name": "isOpenPanelwCome",
-        "description": "コメント欄を開いていても黒帯パネルを表示する",
-        "type": "boolean",
-        "isInstantChangable": true
     }
     ];
 var ComeColorSettingList = [
@@ -252,8 +266,9 @@ var RadioSettingList = [
         "name": "proSamePosition",
         "list":[[
                 ["over","重ねる"],
-                ["vertical","縦(コメ入力欄周辺で無効)"],
-                ["horizontal","横(同)"]
+                ["vertical","縦"],
+                ["horizontal","横(コメ欄周辺で無効)"],
+                ["horizshort","タイトルを少し左へ"]
             ]]
     }
     ];


### PR DESCRIPTION
//気になりそうな点
//コメ欄常時表示時に画面クリックで見た目も一旦閉じる（内部と同じ）
//大きい文字使用時にタイトルが長い場合、余計に感じる改行や各メニューとの重なりが生じる
//コメント表示中に黒帯メニュー表示時、右下のコメ欄開くボタンによるコメ一覧表示切替が効かない
//時計バーによる一時保存画面の表示切替が文字部分クリックでのみ発動
//時計バーの背景区切りと文字が多くなると残り時間の裏がごちゃごちゃして見づらくなる
//一時保存画面で3種類の設定が同時に存在(一時保存後に反映、変更ごとに仮反映、変更ごとに反映)